### PR TITLE
Increment version to 6.4 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [6.4] - 2025-09-10
+
+- Add test email functionality to broadcast variations
+- Fix permissions for test emails to require read template and write contact permissions
+
 ## [6.3] - 2025-09-08
 
 - Fix set permissions on root user

--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const VERSION = "6.3"
+const VERSION = "6.4"
 
 type Config struct {
 	Server          ServerConfig


### PR DESCRIPTION
Update version to 6.4 in config.go and add changelog entry

- Updated VERSION constant from "6.3" to "6.4" in config/config.go
- Added new changelog entry for version 6.4 documenting test email functionality

Fixes #19

Generated with [Claude Code](https://claude.ai/code)