### PR TITLE
Investigate default db prefix in demo env

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -119,6 +119,9 @@ func main() {
 		log.Fatalf("Failed to load configuration: %v", err)
 	}
 
+	// Log the loaded DB_PREFIX for debugging
+	log.Printf("Configuration loaded - DB_PREFIX from config: '%s', DB_PREFIX from environment: '%s'", cfg.Database.Prefix, os.Getenv("DB_PREFIX"))
+
 	// Initialize logger with configured log level
 	appLogger := logger.NewLoggerWithLevel(cfg.LogLevel)
 	appLogger.Info(fmt.Sprintf("Starting API server on %s:%d", cfg.Server.Host, cfg.Server.Port))

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -229,6 +229,7 @@ func (a *App) InitDB() error {
 		maskedPassword = fmt.Sprintf("%c...%c", password[0], password[len(password)-1])
 	}
 	a.logger.Info(fmt.Sprintf("Connecting to database %s:%d, user %s, sslmode %s, password: %s, dbname: %s", a.config.Database.Host, a.config.Database.Port, a.config.Database.User, a.config.Database.SSLMode, maskedPassword, a.config.Database.DBName))
+	a.logger.Info(fmt.Sprintf("Database prefix configured: '%s' (workspace databases will be named: %s_ws_*)", a.config.Database.Prefix, a.config.Database.Prefix))
 
 	// Ensure system database exists
 	if err := database.EnsureSystemDatabaseExists(database.GetPostgresDSN(&a.config.Database), a.config.Database.DBName); err != nil {

--- a/internal/migrations/manager.go
+++ b/internal/migrations/manager.go
@@ -31,6 +31,10 @@ func (c *defaultConnector) connectToWorkspace(cfg *config.DatabaseConfig, worksp
 	// Replace hyphens with underscores for PostgreSQL compatibility
 	safeID := strings.ReplaceAll(workspaceID, "-", "_")
 	dbName := fmt.Sprintf("%s_ws_%s", cfg.Prefix, safeID)
+	
+	// Debug logging to trace prefix usage
+	fmt.Printf("[DEBUG] Migration connector - Using prefix '%s' to connect to workspace '%s' -> database '%s'\n", cfg.Prefix, workspaceID, dbName)
+	
 	dsn := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
 		cfg.User,
 		cfg.Password,


### PR DESCRIPTION
Add debug logging for `DB_PREFIX` to diagnose incorrect database prefix usage in the demo environment.

The user reported that the `DB_PREFIX` environment variable was set, but the application (specifically during migrations) was still using the default `notifuse_` prefix. This PR adds detailed logging at key points in the configuration and database connection flow to pinpoint exactly where the `DB_PREFIX` value might be getting lost or overridden, or if the environment variable is not being read by the process as expected.

---
<a href="https://cursor.com/background-agent?bcId=bc-425fd984-7291-4a87-bdd2-955844541ab7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-425fd984-7291-4a87-bdd2-955844541ab7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

