### PR TITLE
Update version, document smtp fix, and merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [13.5] - 2025-10-23
+
+- Fix: SMTP transport now supports multiple CC and BCC recipients
+
 ## [13.4] - 2025-10-22
 
 - Fix: segment filters now support multiple values for contains/not_contains operators

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const VERSION = "13.4"
+const VERSION = "13.5"
 
 type Config struct {
 	Server          ServerConfig


### PR DESCRIPTION
Increment minor version to 13.5 and document the fix for multi CC/BCC recipients in SMTP transport.

---
<a href="https://cursor.com/background-agent?bcId=bc-896d65fa-542c-45ee-b323-51d76006e320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-896d65fa-542c-45ee-b323-51d76006e320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

