### PR TITLE
Fix docker support for background agent

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,4 +1,4 @@
 {
-  "install": "curl -fsSL https://get.docker.com -o get-docker.sh && sudo sh get-docker.sh && sudo usermod -aG docker $USER && rm get-docker.sh",
-  "start": "sudo service docker start && sleep 5 && until docker info > /dev/null 2>&1; do sleep 1; done && docker compose version"
+  "install": "curl -fsSL https://get.docker.com -o get-docker.sh && sudo sh get-docker.sh && sudo usermod -aG docker $USER && rm get-docker.sh && sudo mkdir -p /etc/docker && echo '{\"storage-driver\":\"vfs\",\"iptables\":false,\"ip-forward\":false,\"ip-masq\":false,\"userland-proxy\":false,\"bridge\":\"none\"}' | sudo tee /etc/docker/daemon.json > /dev/null",
+  "start": "sudo service docker start && sleep 3 && sudo chmod 666 /var/run/docker.sock && until docker info > /dev/null 2>&1; do sleep 1; done && echo 'Docker is ready' && docker --version && docker compose version"
 }


### PR DESCRIPTION
Configure Docker in background agents to use `vfs` storage driver and disable iptables, resolving startup failures and permission issues.

The Docker daemon failed to start in the background agent environment due to the default `overlay2` storage driver being unsupported, `iptables` not being available, and initial socket permission problems. This PR updates the `install` and `start` commands to create a `daemon.json` with `vfs` storage, `iptables: false`, and other network settings disabled, along with ensuring correct socket permissions and service startup.

---
<a href="https://cursor.com/background-agent?bcId=bc-3cfa3ca1-6723-41e4-8868-7e61522eaf35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3cfa3ca1-6723-41e4-8868-7e61522eaf35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

