### PR TITLE
Update version and changelog for email API override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [13.7] - 2025-10-25
+
+- New feature: transactional email API now supports `from_name` parameter to override the default sender name
+
 ## [13.6] - 2025-10-24
 
 - Upgrade github.com/wneessen/go-mail from v0.7.1 to v0.7.2

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const VERSION = "13.6"
+const VERSION = "13.7"
 
 type Config struct {
 	Server          ServerConfig


### PR DESCRIPTION
Increase minor version and update changelog to document the new `from_name` override feature in the transactional email API.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb433dfe-6d83-416e-b90e-138cb70365ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cb433dfe-6d83-416e-b90e-138cb70365ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

