### PR TITLE
Configure cursor agent for postgresql and mailhog

### DIFF
--- a/.cursor/docker-compose.agent.yml
+++ b/.cursor/docker-compose.agent.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    ports:
+      - '5432:5432'
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postgres
+    volumes:
+      - postgres-agent-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  mailhog:
+    image: mailhog/mailhog:latest
+    ports:
+      - '1025:1025' # SMTP server
+      - '8025:8025' # Web UI
+    environment:
+      MH_STORAGE: memory
+    healthcheck:
+      test: ['CMD', 'wget', '--quiet', '--tries=1', '--spider', 'http://localhost:8025/']
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  postgres-agent-data:
+    driver: local

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,4 +1,4 @@
 {
   "install": "curl -fsSL https://get.docker.com -o get-docker.sh && sudo sh get-docker.sh && sudo usermod -aG docker $USER && rm get-docker.sh && sudo mkdir -p /etc/docker && echo '{\"storage-driver\":\"vfs\",\"iptables\":false,\"ip-forward\":false,\"ip-masq\":false,\"userland-proxy\":false,\"bridge\":\"none\"}' | sudo tee /etc/docker/daemon.json > /dev/null",
-  "start": "sudo service docker start && sleep 3 && sudo chmod 666 /var/run/docker.sock && until docker info > /dev/null 2>&1; do sleep 1; done && echo 'Docker is ready' && docker --version && docker compose version"
+  "start": "sudo service docker start && sleep 3 && sudo chmod 666 /var/run/docker.sock && until docker info > /dev/null 2>&1; do sleep 1; done && echo 'Docker is ready' && docker --version && docker compose version && cd /workspace && docker compose -f .cursor/docker-compose.agent.yml up -d && echo 'PostgreSQL available at localhost:5432 (user: postgres, password: postgres)' && echo 'Mailhog UI available at http://localhost:8025' && echo 'Mailhog SMTP available at localhost:1025'"
 }


### PR DESCRIPTION
Configure Cursor agent environment to automatically start PostgreSQL and Mailhog.

---
<a href="https://cursor.com/background-agent?bcId=bc-30fa9946-2fda-408b-8926-bb74ba4ac1e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-30fa9946-2fda-408b-8926-bb74ba4ac1e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

