### PR TITLE
Rename timezone from 'Kiev' to 'Kyiv'

### DIFF
--- a/internal/domain/timezones.go
+++ b/internal/domain/timezones.go
@@ -337,7 +337,7 @@ var Timezones = []string{
 	"Europe/Istanbul",
 	"Europe/Jersey",
 	"Europe/Kaliningrad",
-	"Europe/Kiev",
+	"Europe/Kyiv",
 	"Europe/Kirov",
 	"Europe/Lisbon",
 	"Europe/Ljubljana",


### PR DESCRIPTION
This pull request updates the spelling of “Kiev” → “Kyiv” to reflect the correct and internationally recognized transliteration of the Ukrainian capital’s name.

The change aligns with the official Ukrainian government transliteration system and the United Nations, ISO, and U.S. State Department standards, which all recognize “Kyiv” as the proper English form.