### PR TITLE
Update version and changelog for smtp autodiscover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [16.3] - 2025-11-15
+
+### Fixes
+
+- Fix: Replace hardcoded SMTP PLAIN auth with auto-discover to support Azure Communication Email and other providers requiring LOGIN authentication
+
 ## [16.2] - 2025-11-14
 
 ### Fixes

--- a/config/config.go
+++ b/config/config.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const VERSION = "16.2"
+const VERSION = "16.3"
 
 type Config struct {
 	Server          ServerConfig


### PR DESCRIPTION
Bump minor version to 16.3 and update CHANGELOG.md to reflect the fix replacing hardcoded SMTP PLAIN auth with auto-discover.

---
<a href="https://cursor.com/background-agent?bcId=bc-adc28129-4426-47f2-afb6-196e0e44b8f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-adc28129-4426-47f2-afb6-196e0e44b8f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps version to 16.3 and adds changelog entry noting SMTP auth auto-discovery replacing hardcoded PLAIN to support providers requiring LOGIN.
> 
> - **Versioning**
>   - Update `config/config.go` `VERSION` to `16.3`.
> - **Changelog**
>   - Add `16.3` entry: switch SMTP auth from hardcoded PLAIN to auto-discover (supports LOGIN, e.g., Azure Communication Email).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 277cdf67e16f610167ea8082d295dab6c8292b1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->