### PR TITLE
fix: convert <br> tags to <br /> for proper MJML XML compatibility #216

### DIFF
--- a/console/src/components/mjml-converter/mjml-to-json-browser.ts
+++ b/console/src/components/mjml-converter/mjml-to-json-browser.ts
@@ -53,6 +53,11 @@ export function preprocessMjml(mjmlString: string): string {
     return '="' + fixed + '"'
   })
 
+  // Fix <br> tags to be self-closing <br /> for proper MJML/XML compatibility
+  // This fixes the common issue where HTML-style <br> tags cause XML parsing errors
+  // when importing MJML templates that were exported with unclosed <br> tags
+  processed = processed.replace(/<br\s*>/g, '<br />')
+
   // Fix duplicate attributes in opening tags
   // Match opening tags like <mj-section ...> or <mj-button ... />
   processed = processed.replace(/<([^>]+)>/g, (fullMatch, tagContent) => {


### PR DESCRIPTION
# Description

Fixes an error when importing MJML templates exported from Notifuse, which previously failed with the following error 
```
Failed to convert MJML to JSON:
Error: Invalid MJML syntax: XML Parsing Error: mismatched tag. Expected: </br>
```

# Root Cause

In HTML, `<br>` tags are void elements and do not require a closing tag.  
However, MJML is XML-based, where all void elements **must be self-closing**.

When users export MJML from Notifuse and attempt to import it back, the presence of `<br>` (instead of `<br />`) causes XML parsing errors.

# Solution

Updated the `preprocessMjml` function to normalize `<br>` tags into valid XML-compatible self-closing tags before parsing.

**File updated:**

`console/src/components/mjml-converter/mjml-to-json-browser.ts`

```ts
// Fix <br> tags to be self-closing <br /> for proper MJML/XML compatibility
processed = processed.replace(/<br\s*>/g, '<br />');
```

# Related

Fixes #216