### PR TITLE
feat: inbound reply detection (stop-on-reply) — #346

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [33.0] - 2026-06-10
+
+### Database Schema Changes
+
+- Migration v33.0 redefines the workspace-level `track_inbound_webhook_event_changes()` trigger function so inbound webhook events of type `reply` are recorded on the contact timeline with the dedicated kind `email.replied` (other inbound events keep their existing kind). No data or column changes.
+
+### Features
+
+- **Feature**: Inbound reply detection (stop-on-reply). A new public endpoint `POST /webhooks/email/inbound?workspace_id={id}&integration_id={id}` ingests reply emails forwarded by a provider's inbound parsing feature (Mailgun Routes first). The sender is matched to an existing contact and, when found, an `email.replied` event is recorded on the contact timeline. `email.replied` is now a valid automation trigger event kind, so sequence automations can react to replies (e.g. exit the journey). Replies from unknown senders are ignored. Matching is by sender address in this first cut; `In-Reply-To`/`Message-Id` is captured for future per-send attribution (#346).
+
 ## [32.2] - 2026-05-31
 
 - **Feature**: Exposed `{{ workspace.website_url }}` in email templates — the workspace's public Website URL (trailing slash trimmed), distinct from `{{ workspace.base_url }}` (the tracking endpoint) — so templates can compose application links like `{{ workspace.website_url }}/users/verify/xxx` instead of pointing at the tracking domain (#342).

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const VERSION = "32.2"
+const VERSION = "33.0"
 
 type Config struct {
 	Server              ServerConfig

--- a/internal/database/init.go
+++ b/internal/database/init.go
@@ -663,9 +663,19 @@ func InitializeWorkspaceDatabase(db *sql.DB) error {
 		DECLARE
 			changes_json JSONB := '{}'::jsonb;
 			entity_id_value VARCHAR(255);
+			kind_value VARCHAR(50);
 		BEGIN
 			-- Use message_id if available, otherwise use inbound webhook event id
 			entity_id_value := COALESCE(NEW.message_id, NEW.id::text);
+
+			-- Reply events get a dedicated timeline kind ("email.replied") so
+			-- automations can trigger on them; all other inbound webhook events
+			-- keep the generic kind.
+			IF NEW.type = 'reply' THEN
+				kind_value := 'email.replied';
+			ELSE
+				kind_value := 'insert_inbound_webhook_event';
+			END IF;
 
 			changes_json := jsonb_build_object('type', jsonb_build_object('new', NEW.type), 'source', jsonb_build_object('new', NEW.source));
 			IF NEW.bounce_type IS NOT NULL AND NEW.bounce_type != '' THEN changes_json := changes_json || jsonb_build_object('bounce_type', jsonb_build_object('new', NEW.bounce_type)); END IF;
@@ -673,7 +683,7 @@ func InitializeWorkspaceDatabase(db *sql.DB) error {
 			IF NEW.bounce_diagnostic IS NOT NULL AND NEW.bounce_diagnostic != '' THEN changes_json := changes_json || jsonb_build_object('bounce_diagnostic', jsonb_build_object('new', NEW.bounce_diagnostic)); END IF;
 			IF NEW.complaint_feedback_type IS NOT NULL AND NEW.complaint_feedback_type != '' THEN changes_json := changes_json || jsonb_build_object('complaint_feedback_type', jsonb_build_object('new', NEW.complaint_feedback_type)); END IF;
 			INSERT INTO contact_timeline (email, operation, entity_type, kind, entity_id, changes, created_at)
-			VALUES (NEW.recipient_email, 'insert', 'inbound_webhook_event', 'insert_inbound_webhook_event', entity_id_value, changes_json, CURRENT_TIMESTAMP);
+			VALUES (NEW.recipient_email, 'insert', 'inbound_webhook_event', kind_value, entity_id_value, changes_json, CURRENT_TIMESTAMP);
 			RETURN NEW;
 		END;
 		$$ LANGUAGE plpgsql;`,

--- a/internal/domain/automation.go
+++ b/internal/domain/automation.go
@@ -60,6 +60,8 @@ var ValidEventKinds = []string{
 	// Email events
 	"email.sent", "email.delivered", "email.opened", "email.clicked",
 	"email.bounced", "email.complained", "email.unsubscribed",
+	// Inbound reply event (contact replied to an email we sent)
+	"email.replied",
 	// Custom events (require custom_event_name)
 	"custom_event",
 }

--- a/internal/domain/inbound_webhook_event.go
+++ b/internal/domain/inbound_webhook_event.go
@@ -26,6 +26,14 @@ const (
 	// EmailEventComplaint indicates a complaint was filed for the email
 	EmailEventComplaint EmailEventType = "complaint"
 
+	// EmailEventReply indicates the contact replied to an email we sent.
+	// Unlike the other (outbound-tracking) event types, a reply is an inbound
+	// message: the contact is the SENDER of the incoming email. It is matched
+	// back to a known contact by sender address and surfaced on the contact
+	// timeline as kind "email.replied" so automations can react to it
+	// (e.g. stop-on-reply sequences).
+	EmailEventReply EmailEventType = "reply"
+
 	// EmailEventAuthEmail indicates a Supabase auth email webhook
 	EmailEventAuthEmail EmailEventType = "auth_email"
 
@@ -199,6 +207,7 @@ func (p *InboundWebhookEventListParams) Validate() error {
 			string(EmailEventDelivered),
 			string(EmailEventBounce),
 			string(EmailEventComplaint),
+			string(EmailEventReply),
 		}
 		if !govalidator.IsIn(string(p.EventType), validEventTypes...) {
 			return fmt.Errorf("invalid event type: %s", p.EventType)
@@ -231,6 +240,13 @@ type InboundWebhookEventListResult struct {
 type InboundWebhookEventServiceInterface interface {
 	// ProcessWebhook processes a webhook event from an email provider
 	ProcessWebhook(ctx context.Context, workspaceID, integrationID string, rawPayload []byte) error
+
+	// ProcessInboundReply processes an inbound (reply) email forwarded by a
+	// provider's inbound parsing feature (e.g. Mailgun Routes). The parsed
+	// message fields are passed as form values. It matches the sender to a
+	// known contact and, when found, records an "email.replied" event so
+	// automations can react to it.
+	ProcessInboundReply(ctx context.Context, workspaceID, integrationID string, form url.Values) error
 
 	// ListEvents retrieves all inbound webhook events for a workspace
 	ListEvents(ctx context.Context, workspaceID string, params InboundWebhookEventListParams) (*InboundWebhookEventListResult, error)

--- a/internal/domain/mocks/mock_inbound_webhook_event_service.go
+++ b/internal/domain/mocks/mock_inbound_webhook_event_service.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	context "context"
+	url "net/url"
 	reflect "reflect"
 
 	domain "github.com/Notifuse/notifuse/internal/domain"
@@ -48,6 +49,20 @@ func (m *MockInboundWebhookEventServiceInterface) ListEvents(arg0 context.Contex
 func (mr *MockInboundWebhookEventServiceInterfaceMockRecorder) ListEvents(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEvents", reflect.TypeOf((*MockInboundWebhookEventServiceInterface)(nil).ListEvents), arg0, arg1, arg2)
+}
+
+// ProcessInboundReply mocks base method.
+func (m *MockInboundWebhookEventServiceInterface) ProcessInboundReply(arg0 context.Context, arg1, arg2 string, arg3 url.Values) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProcessInboundReply", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ProcessInboundReply indicates an expected call of ProcessInboundReply.
+func (mr *MockInboundWebhookEventServiceInterfaceMockRecorder) ProcessInboundReply(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessInboundReply", reflect.TypeOf((*MockInboundWebhookEventServiceInterface)(nil).ProcessInboundReply), arg0, arg1, arg2, arg3)
 }
 
 // ProcessWebhook mocks base method.

--- a/internal/http/inbound_webhook_event_handler.go
+++ b/internal/http/inbound_webhook_event_handler.go
@@ -34,6 +34,10 @@ func (h *InboundWebhookEventHandler) RegisterRoutes(mux *http.ServeMux) {
 	// Public webhooks endpoint for receiving events from email providers
 	mux.Handle("/webhooks/email", http.HandlerFunc(h.handleIncomingWebhook))
 
+	// Public endpoint for receiving inbound (reply) messages forwarded by a
+	// provider's inbound parsing feature (e.g. Mailgun Routes).
+	mux.Handle("/webhooks/email/inbound", http.HandlerFunc(h.handleIncomingReply))
+
 	// Authenticated endpoints for accessing inbound webhook event data
 	mux.Handle("/api/inboundWebhookEvents.list", requireAuth(http.HandlerFunc(h.handleList)))
 }
@@ -88,6 +92,52 @@ func (h *InboundWebhookEventHandler) handleIncomingWebhook(w http.ResponseWriter
 	}
 
 	// Return success
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"success": true,
+	})
+}
+
+// handleIncomingReply handles inbound (reply) messages forwarded by a provider's
+// inbound parsing feature. Unlike event webhooks, these are posted as form data
+// (multipart/form-data or application/x-www-form-urlencoded).
+// Format: /webhooks/email/inbound?workspace_id={id}&integration_id={id}
+func (h *InboundWebhookEventHandler) handleIncomingReply(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		WriteJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	workspaceID := r.URL.Query().Get("workspace_id")
+	integrationID := r.URL.Query().Get("integration_id")
+	if workspaceID == "" || integrationID == "" {
+		WriteJSONError(w, "Workspace ID and integration ID are required", http.StatusBadRequest)
+		return
+	}
+
+	// Parse the form. ParseMultipartForm transparently handles
+	// application/x-www-form-urlencoded bodies too, and populates r.PostForm.
+	// 25MB matches the typical provider inbound message size limit.
+	if err := r.ParseMultipartForm(25 << 20); err != nil && err != http.ErrNotMultipart {
+		h.logger.WithField("error", err.Error()).
+			WithField("workspace_id", workspaceID).
+			Error("Failed to parse inbound reply form")
+		WriteJSONError(w, "Failed to parse request body", http.StatusBadRequest)
+		return
+	}
+
+	h.logger.WithField("workspace_id", workspaceID).
+		WithField("integration_id", integrationID).
+		Info("Received inbound reply")
+
+	if err := h.service.ProcessInboundReply(r.Context(), workspaceID, integrationID, r.PostForm); err != nil {
+		h.logger.WithField("error", err.Error()).
+			WithField("workspace_id", workspaceID).
+			WithField("integration_id", integrationID).
+			Error("Failed to process inbound reply")
+		WriteJSONError(w, "Failed to process inbound reply", http.StatusBadRequest)
+		return
+	}
+
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"success": true,
 	})

--- a/internal/http/inbound_webhook_event_handler_test.go
+++ b/internal/http/inbound_webhook_event_handler_test.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -326,4 +328,76 @@ type errorReader struct{}
 
 func (r *errorReader) Read(p []byte) (n int, err error) {
 	return 0, errors.New("simulated read error")
+}
+
+// Tests for handleIncomingReply
+
+func TestInboundWebhookEventHandler_handleIncomingReply_MethodNotAllowed(t *testing.T) {
+	handler, _, _ := setupInboundWebhookEventHandlerTest(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/webhooks/email/inbound", nil)
+	w := httptest.NewRecorder()
+
+	handler.handleIncomingReply(w, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+func TestInboundWebhookEventHandler_handleIncomingReply_MissingParams(t *testing.T) {
+	handler, _, _ := setupInboundWebhookEventHandlerTest(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/email/inbound", nil)
+	w := httptest.NewRecorder()
+
+	handler.handleIncomingReply(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var response map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&response))
+	assert.Equal(t, "Workspace ID and integration ID are required", response["error"])
+}
+
+func TestInboundWebhookEventHandler_handleIncomingReply_Success(t *testing.T) {
+	handler, mockService, _ := setupInboundWebhookEventHandlerTest(t)
+
+	form := url.Values{}
+	form.Set("sender", "jane@example.com")
+	form.Set("subject", "Re: Welcome")
+	form.Set("Message-Id", "<reply-1@mail.example.com>")
+	body := form.Encode()
+
+	mockService.EXPECT().
+		ProcessInboundReply(gomock.Any(), "ws1", "int1", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ string, parsed url.Values) error {
+			assert.Equal(t, "jane@example.com", parsed.Get("sender"))
+			assert.Equal(t, "<reply-1@mail.example.com>", parsed.Get("Message-Id"))
+			return nil
+		})
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/email/inbound?workspace_id=ws1&integration_id=int1", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	handler.handleIncomingReply(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var response map[string]interface{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&response))
+	assert.Equal(t, true, response["success"])
+}
+
+func TestInboundWebhookEventHandler_handleIncomingReply_ServiceError(t *testing.T) {
+	handler, mockService, _ := setupInboundWebhookEventHandlerTest(t)
+
+	mockService.EXPECT().
+		ProcessInboundReply(gomock.Any(), "ws1", "int1", gomock.Any()).
+		Return(errors.New("boom"))
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/email/inbound?workspace_id=ws1&integration_id=int1", strings.NewReader("sender=jane%40example.com"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	handler.handleIncomingReply(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }

--- a/internal/migrations/manager_test.go
+++ b/internal/migrations/manager_test.go
@@ -541,7 +541,7 @@ func TestManager_RunMigrations_AdditionalCoverage(t *testing.T) {
 
 		// Mock GetCurrentDBVersion to return the latest migrated version (up to date)
 		mock.ExpectQuery("SELECT value FROM settings WHERE key = 'db_version'").
-			WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow("32"))
+			WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow("33"))
 
 		err = manager.RunMigrations(context.Background(), cfg, db)
 

--- a/internal/migrations/v33.go
+++ b/internal/migrations/v33.go
@@ -1,0 +1,85 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Notifuse/notifuse/config"
+	"github.com/Notifuse/notifuse/internal/domain"
+)
+
+// V33Migration adds inbound reply detection support.
+//
+// It redefines the workspace-level track_inbound_webhook_event_changes()
+// trigger function so that inbound webhook events of type "reply" are recorded
+// on the contact timeline with the dedicated kind "email.replied" (instead of
+// the generic "insert_inbound_webhook_event"). This lets automations trigger on
+// replies — enabling stop-on-reply sequences. All other inbound webhook events
+// (delivered/bounce/complaint) keep their existing kind, so behaviour for
+// existing data is unchanged.
+//
+// The function is replaced with CREATE OR REPLACE; the existing trigger keeps
+// pointing at it, so no trigger recreation is needed.
+type V33Migration struct{}
+
+func (m *V33Migration) GetMajorVersion() float64 {
+	return 33.0
+}
+
+func (m *V33Migration) HasSystemUpdate() bool {
+	return false
+}
+
+func (m *V33Migration) HasWorkspaceUpdate() bool {
+	return true
+}
+
+func (m *V33Migration) ShouldRestartServer() bool {
+	return false
+}
+
+func (m *V33Migration) UpdateSystem(ctx context.Context, cfg *config.Config, db DBExecutor) error {
+	return nil
+}
+
+func (m *V33Migration) UpdateWorkspace(ctx context.Context, cfg *config.Config, workspace *domain.Workspace, db DBExecutor) error {
+	_, err := db.ExecContext(ctx, `
+		CREATE OR REPLACE FUNCTION track_inbound_webhook_event_changes()
+		RETURNS TRIGGER AS $$
+		DECLARE
+			changes_json JSONB := '{}'::jsonb;
+			entity_id_value VARCHAR(255);
+			kind_value VARCHAR(50);
+		BEGIN
+			-- Use message_id if available, otherwise use inbound webhook event id
+			entity_id_value := COALESCE(NEW.message_id, NEW.id::text);
+
+			-- Reply events get a dedicated timeline kind ("email.replied") so
+			-- automations can trigger on them; all other inbound webhook events
+			-- keep the generic kind.
+			IF NEW.type = 'reply' THEN
+				kind_value := 'email.replied';
+			ELSE
+				kind_value := 'insert_inbound_webhook_event';
+			END IF;
+
+			changes_json := jsonb_build_object('type', jsonb_build_object('new', NEW.type), 'source', jsonb_build_object('new', NEW.source));
+			IF NEW.bounce_type IS NOT NULL AND NEW.bounce_type != '' THEN changes_json := changes_json || jsonb_build_object('bounce_type', jsonb_build_object('new', NEW.bounce_type)); END IF;
+			IF NEW.bounce_category IS NOT NULL AND NEW.bounce_category != '' THEN changes_json := changes_json || jsonb_build_object('bounce_category', jsonb_build_object('new', NEW.bounce_category)); END IF;
+			IF NEW.bounce_diagnostic IS NOT NULL AND NEW.bounce_diagnostic != '' THEN changes_json := changes_json || jsonb_build_object('bounce_diagnostic', jsonb_build_object('new', NEW.bounce_diagnostic)); END IF;
+			IF NEW.complaint_feedback_type IS NOT NULL AND NEW.complaint_feedback_type != '' THEN changes_json := changes_json || jsonb_build_object('complaint_feedback_type', jsonb_build_object('new', NEW.complaint_feedback_type)); END IF;
+			INSERT INTO contact_timeline (email, operation, entity_type, kind, entity_id, changes, created_at)
+			VALUES (NEW.recipient_email, 'insert', 'inbound_webhook_event', kind_value, entity_id_value, changes_json, CURRENT_TIMESTAMP);
+			RETURN NEW;
+		END;
+		$$ LANGUAGE plpgsql;
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to update track_inbound_webhook_event_changes trigger function: %w", err)
+	}
+	return nil
+}
+
+func init() {
+	Register(&V33Migration{})
+}

--- a/internal/service/inbound_reply_service_test.go
+++ b/internal/service/inbound_reply_service_test.go
@@ -1,0 +1,175 @@
+package service
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/Notifuse/notifuse/internal/domain"
+	"github.com/Notifuse/notifuse/internal/domain/mocks"
+	pkgmocks "github.com/Notifuse/notifuse/pkg/mocks"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newReplyTestService wires an InboundWebhookEventService with all-mock deps and
+// a Mailgun workspace/integration ready for inbound-reply tests.
+func newReplyTestService(t *testing.T) (*InboundWebhookEventService, *mocks.MockInboundWebhookEventRepository, *mocks.MockWorkspaceRepository, *mocks.MockContactRepository, string, string) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	repo := mocks.NewMockInboundWebhookEventRepository(ctrl)
+	authService := mocks.NewMockAuthService(ctrl)
+	log := pkgmocks.NewMockLogger(ctrl)
+	workspaceRepo := mocks.NewMockWorkspaceRepository(ctrl)
+	messageHistoryRepo := mocks.NewMockMessageHistoryRepository(ctrl)
+	contactRepo := mocks.NewMockContactRepository(ctrl)
+
+	log.EXPECT().WithField(gomock.Any(), gomock.Any()).Return(log).AnyTimes()
+	log.EXPECT().WithFields(gomock.Any()).Return(log).AnyTimes()
+	log.EXPECT().Info(gomock.Any()).AnyTimes()
+	log.EXPECT().Error(gomock.Any()).AnyTimes()
+
+	workspaceID := "workspace1"
+	integrationID := "integration1"
+
+	workspace := &domain.Workspace{
+		ID: workspaceID,
+		Integrations: []domain.Integration{
+			{
+				ID: integrationID,
+				EmailProvider: domain.EmailProvider{
+					Kind: domain.EmailProviderKindMailgun,
+				},
+			},
+		},
+	}
+	workspaceRepo.EXPECT().GetByID(gomock.Any(), workspaceID).Return(workspace, nil).AnyTimes()
+
+	svc := &InboundWebhookEventService{
+		repo:               repo,
+		authService:        authService,
+		logger:             log,
+		workspaceRepo:      workspaceRepo,
+		messageHistoryRepo: messageHistoryRepo,
+		contactRepo:        contactRepo,
+	}
+	return svc, repo, workspaceRepo, contactRepo, workspaceID, integrationID
+}
+
+func TestProcessInboundReply_KnownContact(t *testing.T) {
+	svc, repo, _, contactRepo, workspaceID, integrationID := newReplyTestService(t)
+
+	form := url.Values{}
+	form.Set("sender", "jane@example.com")
+	form.Set("from", "Jane Doe <jane@example.com>")
+	form.Set("subject", "Re: Welcome aboard")
+	form.Set("Message-Id", "<reply-456@mail.example.com>")
+	form.Set("In-Reply-To", "<orig-123@notifuse>")
+	form.Set("timestamp", "1700000000")
+
+	contactRepo.EXPECT().
+		GetContactByEmail(gomock.Any(), workspaceID, "jane@example.com").
+		Return(&domain.Contact{Email: "jane@example.com"}, nil)
+
+	repo.EXPECT().StoreEvents(gomock.Any(), workspaceID, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, events []*domain.InboundWebhookEvent) error {
+			require.Len(t, events, 1)
+			ev := events[0]
+			assert.Equal(t, domain.EmailEventReply, ev.Type)
+			assert.Equal(t, domain.WebhookSourceMailgun, ev.Source)
+			assert.Equal(t, integrationID, ev.IntegrationID)
+			// RecipientEmail holds the matched contact (the reply's sender).
+			assert.Equal(t, "jane@example.com", ev.RecipientEmail)
+			// In-Reply-To is preferred and stripped of angle brackets.
+			require.NotNil(t, ev.MessageID)
+			assert.Equal(t, "orig-123@notifuse", *ev.MessageID)
+			return nil
+		})
+
+	err := svc.ProcessInboundReply(context.Background(), workspaceID, integrationID, form)
+	assert.NoError(t, err)
+}
+
+func TestProcessInboundReply_UnknownContactIsIgnored(t *testing.T) {
+	svc, repo, _, contactRepo, workspaceID, integrationID := newReplyTestService(t)
+
+	form := url.Values{}
+	form.Set("sender", "stranger@example.com")
+
+	contactRepo.EXPECT().
+		GetContactByEmail(gomock.Any(), workspaceID, "stranger@example.com").
+		Return(nil, nil)
+	// No StoreEvents expected — unknown senders are skipped.
+	repo.EXPECT().StoreEvents(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	err := svc.ProcessInboundReply(context.Background(), workspaceID, integrationID, form)
+	assert.NoError(t, err)
+}
+
+func TestProcessInboundReply_FallsBackToFromHeader(t *testing.T) {
+	svc, repo, _, contactRepo, workspaceID, integrationID := newReplyTestService(t)
+
+	// No "sender" field — must extract the address from the "from" header,
+	// and lowercase it.
+	form := url.Values{}
+	form.Set("from", "Jane Doe <Jane@Example.com>")
+	form.Set("Message-Id", "<reply-456@mail.example.com>")
+
+	contactRepo.EXPECT().
+		GetContactByEmail(gomock.Any(), workspaceID, "jane@example.com").
+		Return(&domain.Contact{Email: "jane@example.com"}, nil)
+
+	repo.EXPECT().StoreEvents(gomock.Any(), workspaceID, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, events []*domain.InboundWebhookEvent) error {
+			require.Len(t, events, 1)
+			assert.Equal(t, "jane@example.com", events[0].RecipientEmail)
+			// Falls back to the reply's own Message-Id when In-Reply-To absent.
+			require.NotNil(t, events[0].MessageID)
+			assert.Equal(t, "reply-456@mail.example.com", *events[0].MessageID)
+			return nil
+		})
+
+	err := svc.ProcessInboundReply(context.Background(), workspaceID, integrationID, form)
+	assert.NoError(t, err)
+}
+
+func TestProcessInboundReply_MissingSender(t *testing.T) {
+	svc, _, _, _, workspaceID, integrationID := newReplyTestService(t)
+
+	form := url.Values{} // no sender, no from
+	err := svc.ProcessInboundReply(context.Background(), workspaceID, integrationID, form)
+	assert.Error(t, err)
+}
+
+func TestProcessInboundReply_UnsupportedProvider(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	log := pkgmocks.NewMockLogger(ctrl)
+	log.EXPECT().WithField(gomock.Any(), gomock.Any()).Return(log).AnyTimes()
+	log.EXPECT().Info(gomock.Any()).AnyTimes()
+	log.EXPECT().Error(gomock.Any()).AnyTimes()
+
+	workspaceRepo := mocks.NewMockWorkspaceRepository(ctrl)
+	workspaceID := "workspace1"
+	integrationID := "integration1"
+	workspaceRepo.EXPECT().GetByID(gomock.Any(), workspaceID).Return(&domain.Workspace{
+		ID: workspaceID,
+		Integrations: []domain.Integration{
+			{ID: integrationID, EmailProvider: domain.EmailProvider{Kind: domain.EmailProviderKindSES}},
+		},
+	}, nil)
+
+	svc := &InboundWebhookEventService{
+		logger:        log,
+		workspaceRepo: workspaceRepo,
+	}
+
+	form := url.Values{}
+	form.Set("sender", "jane@example.com")
+	err := svc.ProcessInboundReply(context.Background(), workspaceID, integrationID, form)
+	assert.Error(t, err)
+}

--- a/internal/service/inbound_webhook_event_service.go
+++ b/internal/service/inbound_webhook_event_service.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/mail"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -210,6 +212,150 @@ func (s *InboundWebhookEventService) ProcessWebhook(ctx context.Context, workspa
 	}
 
 	return nil
+}
+
+// ProcessInboundReply processes an inbound reply email forwarded by a provider's
+// inbound parsing feature. Currently only Mailgun Routes is supported.
+//
+// Matching strategy (MVP): the reply's sender address is matched to an existing
+// contact in the workspace. When a contact is found, an "email.replied" inbound
+// webhook event is stored, which the timeline trigger surfaces as the
+// "email.replied" timeline kind — allowing automations to react (stop-on-reply).
+//
+// Replies from addresses that don't match a known contact are ignored (and the
+// call still succeeds, so the provider does not retry).
+func (s *InboundWebhookEventService) ProcessInboundReply(ctx context.Context, workspaceID string, integrationID string, form url.Values) error {
+	// codecov:ignore:start
+	ctx, span := tracing.StartServiceSpan(ctx, "InboundWebhookEventService", "ProcessInboundReply")
+	defer tracing.EndSpan(span, nil)
+	tracing.AddAttribute(ctx, "workspaceID", workspaceID)
+	tracing.AddAttribute(ctx, "integrationID", integrationID)
+	// codecov:ignore:end
+
+	// Resolve the workspace and integration so we can confirm the provider.
+	workspace, err := s.workspaceRepo.GetByID(ctx, workspaceID)
+	if err != nil {
+		// codecov:ignore:start
+		tracing.MarkSpanError(ctx, err)
+		// codecov:ignore:end
+		return fmt.Errorf("failed to get workspace: %w", err)
+	}
+	var integration domain.Integration
+	found := false
+	for _, i := range workspace.Integrations {
+		if i.ID == integrationID {
+			integration = i
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("integration not found: %s", integrationID)
+	}
+
+	var event *domain.InboundWebhookEvent
+	switch integration.EmailProvider.Kind {
+	case domain.EmailProviderKindMailgun:
+		event, err = s.parseMailgunInboundReply(integration.ID, form)
+	default:
+		// codecov:ignore:start
+		tracing.MarkSpanError(ctx, fmt.Errorf("inbound replies are not supported for provider kind: %s", integration.EmailProvider.Kind))
+		// codecov:ignore:end
+		return fmt.Errorf("inbound replies are not supported for provider kind: %s", integration.EmailProvider.Kind)
+	}
+	if err != nil {
+		// codecov:ignore:start
+		tracing.MarkSpanError(ctx, err)
+		// codecov:ignore:end
+		return fmt.Errorf("failed to parse inbound reply: %w", err)
+	}
+
+	// Match the sender to a known contact. If there is no matching contact we
+	// skip silently — we only care about replies from people we're emailing.
+	contact, err := s.contactRepo.GetContactByEmail(ctx, workspaceID, event.RecipientEmail)
+	if err != nil || contact == nil {
+		s.logger.WithField("workspace_id", workspaceID).
+			WithField("sender", event.RecipientEmail).
+			Info("Ignoring inbound reply from unknown contact")
+		return nil
+	}
+
+	// Store the event. The timeline trigger records it as an "email.replied"
+	// timeline entry, which fires any automation listening for replies.
+	if err := s.repo.StoreEvents(ctx, workspaceID, []*domain.InboundWebhookEvent{event}); err != nil {
+		// codecov:ignore:start
+		tracing.MarkSpanError(ctx, err)
+		// codecov:ignore:end
+		return fmt.Errorf("failed to store inbound reply event: %w", err)
+	}
+
+	return nil
+}
+
+// parseMailgunInboundReply builds a reply InboundWebhookEvent from a Mailgun
+// Routes inbound message POST (multipart/form-data or urlencoded fields).
+// See https://documentation.mailgun.com/docs/mailgun/user-manual/receive-forward-store/
+func (s *InboundWebhookEventService) parseMailgunInboundReply(integrationID string, form url.Values) (*domain.InboundWebhookEvent, error) {
+	// "sender" is the SMTP envelope sender (a bare address); fall back to
+	// parsing the "from" header (e.g. `Jane Doe <jane@example.com>`).
+	senderEmail := strings.TrimSpace(form.Get("sender"))
+	if senderEmail == "" {
+		senderEmail = extractEmailAddress(form.Get("from"))
+	} else {
+		senderEmail = extractEmailAddress(senderEmail)
+	}
+	if senderEmail == "" {
+		return nil, fmt.Errorf("inbound reply is missing a sender address")
+	}
+	senderEmail = strings.ToLower(senderEmail)
+
+	// Prefer the original message's id (In-Reply-To) so the event can later be
+	// attributed to the specific send; fall back to the reply's own Message-Id.
+	messageID := strings.TrimSpace(form.Get("In-Reply-To"))
+	if messageID == "" {
+		messageID = strings.TrimSpace(form.Get("Message-Id"))
+	}
+	messageID = strings.Trim(messageID, "<>")
+
+	// Mailgun includes a unix "timestamp" field (also used for signing).
+	timestamp := time.Now().UTC()
+	if ts := form.Get("timestamp"); ts != "" {
+		if seconds, convErr := strconv.ParseInt(ts, 10, 64); convErr == nil {
+			timestamp = time.Unix(seconds, 0).UTC()
+		}
+	}
+
+	var messageIDPtr *string
+	if messageID != "" {
+		messageIDPtr = &messageID
+	}
+
+	// RecipientEmail carries the matched contact (the reply's sender) so the
+	// timeline trigger attaches the "email.replied" entry to the right contact.
+	return domain.NewInboundWebhookEvent(
+		uuid.New().String(),
+		domain.EmailEventReply,
+		domain.WebhookSourceMailgun,
+		integrationID,
+		senderEmail,
+		messageIDPtr,
+		timestamp,
+		form.Encode(),
+	), nil
+}
+
+// extractEmailAddress returns the bare email address from a header value that
+// may be in "Name <addr@example.com>" form, or the trimmed input if it is
+// already a plain address.
+func extractEmailAddress(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if addr, err := mail.ParseAddress(value); err == nil {
+		return addr.Address
+	}
+	return value
 }
 
 // dedupeStrings returns a new slice with duplicates removed, preserving the

--- a/plans/reply-detection-inbound-plan.md
+++ b/plans/reply-detection-inbound-plan.md
@@ -1,0 +1,82 @@
+# Inbound Reply Detection (stop-on-reply) — Plan
+
+Implements the **inbound ingestion** layer of issue #346: ingest reply emails and
+emit an `email.replied` event that automations can trigger on (enabling
+stop-on-reply sequences). Scope is intentionally limited to inbound ingestion +
+event emission — the automation that reacts to the reply is built by the user
+with the existing automation builder (the trigger mechanism already exists).
+
+## Decisions
+
+- **Provider (first cut):** Mailgun Routes inbound parsing. The handler/service
+  are structured so other providers (Postmark Inbound, SES Inbound via SNS) slot
+  in behind the same endpoint by switching on the integration's provider kind.
+- **Reply→contact matching (first cut):** by **sender address**. The reply's
+  `sender` (fallback: parsed `from` header) is matched to an existing contact.
+  This needs no changes to outbound sending and is sufficient for stop-on-reply
+  (we only need to know *that* a known contact replied). `In-Reply-To` /
+  `Message-Id` are captured on the event for future per-send attribution.
+- **Event surfacing:** replies are stored in the existing `inbound_webhook_events`
+  table with `type = "reply"`, and the timeline trigger emits the dedicated
+  contact-timeline kind `email.replied`. This reuses the existing inbound
+  multi-provider pattern and the existing automation trigger mechanism
+  (automation triggers fire on `contact_timeline` inserts whose `kind` matches
+  the trigger's event kind).
+
+## Why `email.replied` (not `reply_email`)
+
+Automation triggers compare `contact_timeline.kind` to the configured event kind
+literally (`automation_trigger_generator.go` `buildWHENClause`). The working
+trigger kinds (`segment.joined`, `list.subscribed`, `custom_event.*`,
+`contact.created`) are dotted and match `ValidEventKinds` exactly. Using the
+dotted `email.replied` both in `ValidEventKinds` and as the timeline kind keeps
+the trigger self-consistent. (Note: the message-history-sourced email kinds use
+a different `verb_channel` shape — `open_email`, `click_email` — which does *not*
+match the dotted `email.opened` in `ValidEventKinds`; that pre-existing
+inconsistency is out of scope here and untouched.)
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `internal/domain/inbound_webhook_event.go` | New `EmailEventReply` type; `ProcessInboundReply` on the service interface; allow `reply` in the list filter. |
+| `internal/domain/automation.go` | Add `email.replied` to `ValidEventKinds`. |
+| `internal/database/init.go` | `track_inbound_webhook_event_changes()` emits `email.replied` for `type = 'reply'`. |
+| `internal/migrations/v33.go` | Workspace migration re-creating the trigger function on existing installs. |
+| `config/config.go` | `VERSION` 32.2 → 33.0. |
+| `internal/service/inbound_webhook_event_service.go` | `ProcessInboundReply` + `parseMailgunInboundReply` + `extractEmailAddress`. |
+| `internal/http/inbound_webhook_event_handler.go` | Route `POST /webhooks/email/inbound` + `handleIncomingReply` (multipart/urlencoded form parsing). |
+| `internal/domain/mocks/mock_inbound_webhook_event_service.go` | Hand-added `ProcessInboundReply` (no mockgen in env). |
+| `internal/migrations/manager_test.go` | "up to date" version 32 → 33. |
+| `CHANGELOG.md` | 33.0 entry. |
+
+## Tests
+
+- `internal/service/inbound_reply_service_test.go`: known-contact happy path
+  (asserts reply event shape + `In-Reply-To` preference), unknown contact
+  ignored (no store), `from`-header fallback + lowercasing + `Message-Id`
+  fallback, missing sender error, unsupported provider error.
+- `internal/http/inbound_webhook_event_handler_test.go`: method-not-allowed,
+  missing params, success (form parsed and forwarded), service error.
+
+## Provider setup (Mailgun)
+
+Create a Mailgun Route with action
+`forward("https://<host>/webhooks/email/inbound?workspace_id=<ws>&integration_id=<int>")`
+(store-and-notify also works). Set the campaign/automation emails' `Reply-To`
+(or `From`) to a domain Mailgun receives, so replies land on the Route.
+
+## Out of scope / follow-ups
+
+- **Signature verification:** the existing event webhook handler doesn't verify
+  provider signatures; this endpoint matches that for parity. Forged replies can
+  at most stop a sequence early. Hardening (Mailgun timestamp/token/signature
+  HMAC) is a follow-up.
+- **Other providers:** Postmark Inbound, SES Inbound via SNS.
+- **Per-send attribution:** match `In-Reply-To`/`References` to a stored
+  `Message-Id` (needs persisting the SMTP Message-Id per send).
+- **Restrict to recent recipients:** only emit when the contact actually has a
+  recent send (reduces noise from unrelated inbound).
+- **OpenAPI:** document the new endpoint in `openapi.json` (generated file).
+- **Console UI:** the automation builder already lists trigger event kinds from
+  `ValidEventKinds`; verify `email.replied` is selectable / labeled there.

--- a/tests/integration/inbound_reply_test.go
+++ b/tests/integration/inbound_reply_test.go
@@ -1,0 +1,117 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Notifuse/notifuse/config"
+	"github.com/Notifuse/notifuse/internal/app"
+	"github.com/Notifuse/notifuse/internal/domain"
+	"github.com/Notifuse/notifuse/tests/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInboundReplyDetection exercises the inbound-reply layer of issue #346
+// end-to-end: a Mailgun Routes-style inbound POST for a known contact must
+// produce an "email.replied" entry on the contact timeline (the event that
+// automations trigger on), while a reply from an unknown sender produces none.
+func TestInboundReplyDetection(t *testing.T) {
+	testutil.SkipIfShort(t)
+	testutil.SetupTestEnvironment()
+	defer testutil.CleanupTestEnvironment()
+
+	suite := testutil.NewIntegrationTestSuite(t, func(cfg *config.Config) testutil.AppInterface {
+		return app.NewApp(cfg)
+	})
+	defer func() { suite.Cleanup() }()
+
+	factory := suite.DataFactory
+
+	user, err := factory.CreateUser()
+	require.NoError(t, err)
+	workspace, err := factory.CreateWorkspace()
+	require.NoError(t, err)
+	require.NoError(t, factory.AddUserToWorkspace(user.ID, workspace.ID, "owner"))
+
+	// A Mailgun email integration is required for the inbound endpoint to accept
+	// the reply (the service dispatches on the integration's provider kind).
+	integration, err := factory.CreateIntegration(workspace.ID, testutil.WithIntegrationEmailProvider(domain.EmailProvider{
+		Kind: domain.EmailProviderKindMailgun,
+		Senders: []domain.EmailSender{
+			domain.NewEmailSender("hello@example.com", "Hello"),
+		},
+		Mailgun: &domain.MailgunSettings{
+			Domain: "example.com",
+			Region: "US",
+		},
+	}))
+	require.NoError(t, err)
+
+	inboundURL := suite.ServerManager.GetURL() + fmt.Sprintf(
+		"/webhooks/email/inbound?workspace_id=%s&integration_id=%s", workspace.ID, integration.ID)
+
+	postReply := func(t *testing.T, form url.Values) *http.Response {
+		t.Helper()
+		resp, err := http.Post(inboundURL, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		return resp
+	}
+
+	// waitForRepliedEvent polls the contact timeline for an "email.replied"
+	// entry (the timeline write happens in the same transaction as the inbound
+	// event insert, but we poll briefly to avoid any ordering flakiness).
+	waitForRepliedEvent := func(t *testing.T, email string) int {
+		t.Helper()
+		deadline := time.Now().Add(3 * time.Second)
+		for {
+			events, err := factory.GetContactTimelineEvents(workspace.ID, email, "email.replied")
+			require.NoError(t, err)
+			if len(events) > 0 || time.Now().After(deadline) {
+				return len(events)
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+
+	t.Run("KnownContactEmitsEmailReplied", func(t *testing.T) {
+		contactEmail := fmt.Sprintf("replier-%d@example.com", time.Now().UnixNano())
+		_, err := factory.CreateContact(workspace.ID, testutil.WithContactEmail(contactEmail))
+		require.NoError(t, err)
+
+		form := url.Values{}
+		form.Set("sender", contactEmail)
+		form.Set("from", "Replier <"+contactEmail+">")
+		form.Set("subject", "Re: Welcome aboard")
+		form.Set("Message-Id", "<reply-1@mail.example.com>")
+		form.Set("In-Reply-To", "<orig-1@notifuse>")
+		form.Set("timestamp", "1700000000")
+
+		resp := postReply(t, form)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		count := waitForRepliedEvent(t, contactEmail)
+		assert.GreaterOrEqual(t, count, 1, "expected an email.replied timeline entry for the known contact")
+	})
+
+	t.Run("UnknownSenderIsIgnored", func(t *testing.T) {
+		unknownEmail := fmt.Sprintf("stranger-%d@example.com", time.Now().UnixNano())
+
+		form := url.Values{}
+		form.Set("sender", unknownEmail)
+		form.Set("subject", "Re: Welcome aboard")
+
+		resp := postReply(t, form)
+		// Still 200 so the provider does not retry.
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		events, err := factory.GetContactTimelineEvents(workspace.ID, unknownEmail, "email.replied")
+		require.NoError(t, err)
+		assert.Len(t, events, 0, "unknown senders must not produce a timeline entry")
+	})
+}


### PR DESCRIPTION
Closes #346 (inbound-ingestion layer).

## What

Adds the missing primitive from #346 — **inbound email ingestion** — so a contact's reply becomes an `email.replied` event that automations can trigger on (e.g. exit a sequence when the contact replies). The reaction itself reuses the existing automation builder; this PR only adds the new building block.

## How

- **New public endpoint** `POST /webhooks/email/inbound?workspace_id=..&integration_id=..` ingests reply emails forwarded by a provider's inbound parsing feature. **Mailgun Routes** is implemented first; the handler/service dispatch on the integration's provider kind so Postmark Inbound / SES Inbound slot in behind the same endpoint.
- **Reply→contact matching by sender address** (first cut): the reply's `sender` (fallback: parsed `from` header) is matched to an existing contact. No outbound-sending changes required. `In-Reply-To`/`Message-Id` are captured on the event for future per-send attribution.
- Replies are stored as inbound webhook events of type `reply`; the `track_inbound_webhook_event_changes` trigger surfaces them on the contact timeline with the dedicated kind **`email.replied`**, which fires automations. Replies from unknown senders are ignored (and still return 200 so the provider doesn't retry).
- `email.replied` added to the automation trigger event kinds (`ValidEventKinds`).
- **Migration v33** redefines the workspace trigger function on existing installs; `VERSION` 32.2 → 33.0. No column/data changes.

`email.replied` (dotted) is used both in `ValidEventKinds` and as the timeline kind so the generated trigger WHEN clause (`NEW.kind = 'email.replied'`) matches — consistent with the other working trigger kinds (`segment.joined`, `list.subscribed`, `custom_event.*`).

## Tests

- Unit: service (`ProcessInboundReply` — known contact, unknown sender ignored, `from`-header fallback + lowercasing, missing sender, unsupported provider) and HTTP handler.
- End-to-end (`tests/integration/inbound_reply_test.go`): posts a Mailgun-style inbound form and asserts an `email.replied` timeline entry for a known contact and none for an unknown sender. Passes against real Postgres.

## Tested locally

Validated end-to-end on a local Docker stack (`docker compose up`), not just in automated tests:

1. Completed the setup wizard, created a workspace and a **Mailgun email integration** via the console.
2. `POST /webhooks/email/inbound` with `sender` = an existing contact returned `{"success":true}`.
3. Confirmed the contact timeline got a row with `kind = email.replied`, `entity_id` = the `In-Reply-To` value, `changes = {type: reply, source: mailgun}`.
4. Confirmed a reply from an address with no matching contact is ignored (no timeline entry).

## Out of scope (follow-ups)

- **Mailgun Route auto-registration:** the integration's "register webhook" button only registers *event* webhooks (`delivered`/`permanent_fail`/`temporary_fail`/`complained`) via `/v3/domains/{domain}/webhooks`. Receiving replies currently requires manually creating a Mailgun **Route** (`forward()` → this endpoint). Auto-creating that Route from the integration is a separate PR.
- Other inbound providers (Postmark, SES via SNS); inbound signature verification (matches the existing event-webhook handler, which also doesn't verify); per-send attribution via stored Message-Id.

See `plans/reply-detection-inbound-plan.md` for the full design.