### PR TITLE
fix(email-builder): keep mj-button/mj-social inner-padding as MJML shorthand

### DIFF
--- a/console/src/components/email_builder/ui/PaddingInput.tsx
+++ b/console/src/components/email_builder/ui/PaddingInput.tsx
@@ -24,10 +24,13 @@ interface MjmlPaddingProps {
 type PaddingInputProps = IndividualPaddingProps | MjmlPaddingProps
 
 const isIndividualPadding = (props: PaddingInputProps): props is IndividualPaddingProps => {
-  return (
-    typeof (props as IndividualPaddingProps).value === 'object' ||
-    (props as IndividualPaddingProps).value === undefined
-  )
+  // Only an explicit object value selects individual (per-side) mode. An `undefined`
+  // value must fall through to MJML shorthand (string) mode — otherwise single-attribute
+  // callers like mj-button / mj-social `inner-padding` would emit an object into a string
+  // field, which the backend serializes as the Go map literal `map[bottom:0px top:0px]`,
+  // producing invalid CSS that strict clients (Gmail) drop.
+  const value = (props as IndividualPaddingProps).value
+  return typeof value === 'object' && value !== null
 }
 
 /**


### PR DESCRIPTION
## Problem

A button (`mj-button`) silently disappears in Gmail while everything around it renders. Fixes #369.

The visual editor stores the button's **inner padding** as an object, which the backend serializes into the inline CSS as the Go map literal `map[bottom:0px top:0px]`:

```html
<a ... style="...;padding:map[bottom:0px top:0px];...">
```

Browsers and the editor Preview tolerate the invalid declaration and still render the button, so the bug is invisible in preview — but Gmail's CSS sanitizer drops the element.

## Root cause

`console/src/components/email_builder/ui/PaddingInput.tsx` selected its mode with:

```ts
typeof value === 'object' || value === undefined
```

Treating `undefined` as individual (per-side) mode is the bug. The only two callers that bind the single shorthand attribute `inner-padding` — `MjButtonBlock` and `MjSocialBlock` — pass `value={currentAttributes.innerPadding}`, which is `undefined` on a fresh block. That routed them through individual mode, so `onChange` returned an object `{top,right,bottom,left}` into the string-typed `innerPadding` field. The backend's `formatSingleAttributeWithLiquid` then renders unknown values via `fmt.Sprintf("%v", value)`, producing `inner-padding="map[bottom:0px top:0px]"`.

The 8 container-padding callers are unaffected: they pass an explicit object and split it into `paddingTop/Right/Bottom/Left`.

## Fix

Only treat an explicit (non-null) object as individual mode; let `undefined` fall through to MJML shorthand (string) mode. Object-mode callers always pass an explicit object literal, so they are unaffected. This fixes both `mj-button` and `mj-social` inner-padding.

```ts
const isIndividualPadding = (props) => {
  const value = props.value
  return typeof value === 'object' && value !== null
}
```

## Verification

Simulating the mode decision + `onChange` for a fresh button where the user sets top/bottom padding:

```
BEFORE (value=undefined): object -> backend fmt => map[bottom:0px top:0px]
AFTER  (value=undefined): "0px"  (valid shorthand string)
container padding (explicit object): individual before & after  // no regression
```

## Follow-up (not in this PR)

Independently, the backend `default` branch of `formatSingleAttributeWithLiquid` will `fmt.Sprintf("%v", ...)` any map/slice into an attribute value, emitting invalid CSS rather than skipping it. Guarding non-scalar values there would harden against any future object-typed attribute. Happy to add it here or in a separate PR if preferred.
