### PR TITLE
fix: notification center unsubscribe broken since v34.0 (accept SPA JSON body on /unsubscribe-oneclick)

### DIFF
--- a/internal/http/public_handler.go
+++ b/internal/http/public_handler.go
@@ -212,31 +212,55 @@ func (h *NotificationCenterHandler) handleUnsubscribeOneClick(w http.ResponseWri
 		return
 	}
 
-	// RFC 8058 one-click unsubscribe (e.g. the Gmail/Yahoo List-Unsubscribe header
-	// link). Per RFC 8058 (section 2.1) the unsubscribe parameters are carried in the
-	// URL query string (not the POST body); read them from the query here, then
-	// validate the required RFC 8058 body token below.
+	// Two distinct callers POST to this endpoint, with different request shapes:
+	//
+	//  1. The notification center SPA (first-party browser fetch): sends a JSON body
+	//     carrying the identifying params (wid, email, email_hmac, lids, mid) and no
+	//     query string. This is the "Unsubscribe" button and the per-list toggle.
+	//  2. Mail providers (Gmail, Yahoo, Apple) issuing the RFC 8058 List-Unsubscribe
+	//     one-click POST: identifying params in the URL query (RFC 8058 section 2.1)
+	//     and a "List-Unsubscribe=One-Click" token in the body (section 3.1).
+	//
+	// Branch on Content-Type so both contracts are honored on the same endpoint.
+	// Either way authorization is owned by ListService.UnsubscribeFromLists, which
+	// verifies the email_hmac against the workspace secret key.
 	var req domain.UnsubscribeFromListsRequest
-	if err := req.FromOneClickURLParams(r.URL.Query()); err != nil {
-		h.logger.WithField("error", err.Error()).Error("Invalid one-click unsubscribe request")
-		WriteJSONError(w, "Invalid request", http.StatusBadRequest)
-		return
-	}
-
-	// RFC 8058 (section 3.1): the POST body is application/x-www-form-urlencoded
-	// containing "List-Unsubscribe=One-Click". Requiring that token is the
-	// defense-in-depth against link-prefetchers and security scanners that fire a
-	// bare POST: a conformant one-click request always carries it. We do NOT apply
-	// User-Agent bot detection here - an RFC 8058 POST is always machine-generated
-	// by the mail provider, so a UA blocklist only drops legitimate unsubscribes
-	// (the contact stays subscribed while the provider sees success). A missing
-	// token is a real 400, never a silent success. Authorization is the HMAC below.
-	bodyBytes, _ := io.ReadAll(io.LimitReader(r.Body, 4096))
-	if !strings.Contains(string(bodyBytes), "List-Unsubscribe=One-Click") {
-		h.logger.WithField("user_agent", r.Header.Get("User-Agent")).
-			Warn("One-click unsubscribe POST missing RFC 8058 List-Unsubscribe=One-Click token")
-		WriteJSONError(w, "Invalid request", http.StatusBadRequest)
-		return
+	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
+		// First-party SPA path. The HMAC in the body authorizes the request; the body
+		// is decoded into the same struct the one-click params map to (matching json tags).
+		if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&req); err != nil {
+			h.logger.WithField("error", err.Error()).Error("Invalid notification center unsubscribe request body")
+			WriteJSONError(w, "Invalid request", http.StatusBadRequest)
+			return
+		}
+		if req.WorkspaceID == "" || req.Email == "" || len(req.ListIDs) == 0 {
+			h.logger.Error("Notification center unsubscribe request missing required fields")
+			WriteJSONError(w, "Invalid request", http.StatusBadRequest)
+			return
+		}
+	} else {
+		// RFC 8058 one-click path. Per section 2.1 the parameters are carried in the
+		// URL query string (not the body); read them from the query here.
+		if err := req.FromOneClickURLParams(r.URL.Query()); err != nil {
+			h.logger.WithField("error", err.Error()).Error("Invalid one-click unsubscribe request")
+			WriteJSONError(w, "Invalid request", http.StatusBadRequest)
+			return
+		}
+		// RFC 8058 (section 3.1): the body is application/x-www-form-urlencoded
+		// containing "List-Unsubscribe=One-Click". Requiring that token is the
+		// defense-in-depth against link-prefetchers and security scanners that fire a
+		// bare POST: a conformant one-click request always carries it. We do NOT apply
+		// User-Agent bot detection here - an RFC 8058 POST is always machine-generated
+		// by the mail provider, so a UA blocklist only drops legitimate unsubscribes
+		// (the contact stays subscribed while the provider sees success). A missing
+		// token is a real 400, never a silent success.
+		bodyBytes, _ := io.ReadAll(io.LimitReader(r.Body, 4096))
+		if !strings.Contains(string(bodyBytes), "List-Unsubscribe=One-Click") {
+			h.logger.WithField("user_agent", r.Header.Get("User-Agent")).
+				Warn("One-click unsubscribe POST missing RFC 8058 List-Unsubscribe=One-Click token")
+			WriteJSONError(w, "Invalid request", http.StatusBadRequest)
+			return
+		}
 	}
 
 	fromBearerToken := false

--- a/internal/http/public_handler_test.go
+++ b/internal/http/public_handler_test.go
@@ -393,6 +393,54 @@ func TestNotificationCenterHandler_handleUnsubscribeOneClick(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 	})
 
+	// The notification center SPA (first-party browser fetch) posts a JSON body with the
+	// identifying params and no query string. This path was silently broken in v34.0 when
+	// the handler was made RFC 8058-strict (issue #371): it must keep working, authorized
+	// by the email_hmac that ListService verifies.
+	t.Run("unsubscribes via notification center SPA JSON body", func(t *testing.T) {
+		var captured *domain.UnsubscribeFromListsRequest
+		mockListService.EXPECT().
+			UnsubscribeFromLists(gomock.Any(), gomock.Any(), false).
+			DoAndReturn(func(_ context.Context, p *domain.UnsubscribeFromListsRequest, _ bool) error {
+				captured = p
+				return nil
+			})
+
+		body := `{"wid":"ws123","email":"test@example.com","email_hmac":"deadbeef","lids":["list1"],"mid":"msg-1"}`
+		req := httptest.NewRequest(http.MethodPost, "/unsubscribe-oneclick", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+
+		handler.handleUnsubscribeOneClick(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.JSONEq(t, `{"success":true}`, rec.Body.String())
+		require.NotNil(t, captured, "service must be called - the contact must actually be unsubscribed")
+		assert.Equal(t, "ws123", captured.WorkspaceID)
+		assert.Equal(t, "test@example.com", captured.Email)
+		assert.Equal(t, "deadbeef", captured.EmailHMAC)
+		assert.Equal(t, []string{"list1"}, captured.ListIDs)
+		assert.Equal(t, "msg-1", captured.MessageID)
+	})
+
+	// A JSON body that does not structurally identify a contact + list(s) is a 400, with
+	// no service call - same guarantee as the malformed one-click link.
+	jsonRejectCases := []struct{ name, body string }{
+		{"empty object", `{}`},
+		{"missing lids", `{"wid":"ws123","email":"test@example.com"}`},
+		{"missing wid", `{"email":"test@example.com","lids":["list1"]}`},
+		{"malformed json", `{"wid":`},
+	}
+	for _, jc := range jsonRejectCases {
+		t.Run("rejects invalid SPA JSON body: "+jc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/unsubscribe-oneclick", strings.NewReader(jc.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			handler.handleUnsubscribeOneClick(rec, req)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+		})
+	}
+
 	t.Run("service error returns 500", func(t *testing.T) {
 		mockListService.EXPECT().
 			UnsubscribeFromLists(gomock.Any(), gomock.Any(), false).


### PR DESCRIPTION
## Problem

Since **v34.0**, every unsubscribe done from the notification center UI fails with `400 {"error":"Invalid request"}` and the contact stays subscribed. This affects both the **Unsubscribe** action (`/notification-center?action=unsubscribe&...`) and the per-list toggle inside the widget — real broadcasts included.

Fixes #371.

## Root cause

The notification center SPA calls `/unsubscribe-oneclick` with a **JSON body** (`unsubscribeOneClick` → `api.post('/unsubscribe-oneclick', {wid, email, email_hmac, lids, mid})`) and no query string.

The v34.0 fix for #362 rewrote `handleUnsubscribeOneClick` to be strict RFC 8058: it reads the params **only from the URL query** (`FromOneClickURLParams`) and requires a `List-Unsubscribe=One-Click` token in the body. The SPA sends neither, so its request is rejected. Before v34.0 the handler decoded the JSON body, so the #362 fix (needed for Gmail/Yahoo mail-client one-click) silently broke the first-party SPA path — the two callers now have mutually exclusive requirements on the same endpoint.

## Fix

Branch `handleUnsubscribeOneClick` on `Content-Type`:

- `application/json` → decode the SPA body and validate the required fields (`wid`, `email`, `lids`). Authorization stays with the `email_hmac` that `ListService.UnsubscribeFromLists` verifies against the workspace secret key.
- anything else → unchanged RFC 8058 path (query params + `List-Unsubscribe=One-Click` token) for mail-provider one-click.

Both callers now work on the same endpoint; the #362 behavior is preserved.

An alternative would be to make the SPA conform to RFC 8058 (query params + form token), but that is an awkward shape for a first-party authenticated fetch and would not restore existing deployments without a frontend rebuild.

## Tests

`internal/http/public_handler_test.go`:
- new happy path: SPA JSON body → 200, service called with the parsed fields;
- new rejection cases: empty object, missing `lids`, missing `wid`, malformed JSON → 400, no service call;
- all existing RFC 8058 one-click cases still pass.

`go test ./internal/http/` and `go vet ./internal/http/` are green.
