### PR TITLE
Fix Add to List automation node: write status 'active' instead of invalid 'subscribed'

### DIFF
--- a/console/src/components/automations/config/AddToListConfigForm.tsx
+++ b/console/src/components/automations/config/AddToListConfigForm.tsx
@@ -14,7 +14,7 @@ export const AddToListConfigForm: React.FC<AddToListConfigFormProps> = ({ config
   const { lists } = useAutomation()
 
   const STATUS_OPTIONS = [
-    { label: t`Subscribed`, value: 'subscribed' },
+    { label: t`Subscribed`, value: 'active' },
     { label: t`Pending`, value: 'pending' }
   ]
 
@@ -22,7 +22,7 @@ export const AddToListConfigForm: React.FC<AddToListConfigFormProps> = ({ config
     onChange({ ...config, list_id: value })
   }
 
-  const handleStatusChange = (value: 'subscribed' | 'pending') => {
+  const handleStatusChange = (value: 'active' | 'pending') => {
     onChange({ ...config, status: value })
   }
 
@@ -51,7 +51,7 @@ export const AddToListConfigForm: React.FC<AddToListConfigFormProps> = ({ config
         extra={t`The status to assign when adding to the list`}
       >
         <Select
-          value={config.status || 'subscribed'}
+          value={config.status || 'active'}
           onChange={handleStatusChange}
           style={{ width: '100%' }}
           options={STATUS_OPTIONS}


### PR DESCRIPTION
## What

The **Add to List** automation node's config form sends `status: 'subscribed'`, but the backend only accepts `'active'` or `'pending'`. So the node fails at execution with `invalid status: subscribed` and the contact's journey silently ends (the node shows `Completed: 0`). Full details in #376.

This maps the **Subscribed** option to the canonical backend value `'active'`.

## Change

`console/src/components/automations/config/AddToListConfigForm.tsx`:
- `STATUS_OPTIONS`: `{ label: t``Subscribed``, value: 'subscribed' }` → `value: 'active'`
- `handleStatusChange` param type: `'subscribed' | 'pending'` → `'active' | 'pending'`
- default: `config.status || 'subscribed'` → `config.status || 'active'`

This also makes the form consistent with the existing `AddToListNodeConfig` type (`console/src/services/api/automation.ts`), which already declares `status: 'active' | 'pending'`.

## Result

Selecting **Subscribed** now writes `active`, which passes `AddToListNodeConfig.Validate()` and the node completes (contact added to the list as an active subscriber).

Fixes #376
