### PR TITLE
perf: reuse Liquid engines and hoist constant regexes in MJML converter

### DIFF
--- a/pkg/notifuse_mjml/converter.go
+++ b/pkg/notifuse_mjml/converter.go
@@ -5,7 +5,20 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 )
+
+// liquidEnginePool reuses SecureLiquidEngine instances across renders.
+// Creating an engine registers all standard tags on a fresh environment,
+// which is wasteful when rendering many blocks (e.g. during a broadcast).
+// A pool is used instead of a shared instance because liquid.Environment
+// caches strainer classes in an unsynchronized map during rendering, so a
+// single engine must not be used from multiple goroutines concurrently.
+var liquidEnginePool = sync.Pool{
+	New: func() interface{} {
+		return NewSecureLiquidEngine()
+	},
+}
 
 // ConvertJSONToMJML converts an EmailBlock JSON tree to MJML string
 func ConvertJSONToMJML(tree EmailBlock) string {
@@ -282,8 +295,9 @@ func processLiquidContent(content string, templateData map[string]interface{}, b
 	// Clean non-breaking spaces and other invisible characters from template variables
 	content = cleanLiquidTemplate(content)
 
-	// Create secure Liquid engine with timeout and size protections
-	engine := NewSecureLiquidEngine()
+	// Get a secure Liquid engine (timeout and size protections) from the pool
+	engine := liquidEnginePool.Get().(*SecureLiquidEngine)
+	defer liquidEnginePool.Put(engine)
 
 	// Use provided template data or initialize empty map if nil
 	var jsonData map[string]interface{}
@@ -302,20 +316,20 @@ func processLiquidContent(content string, templateData map[string]interface{}, b
 	return renderedContent, nil
 }
 
+// liquidMarkupRegex finds Liquid template variables ({{ }}) and tags ({% %})
+var liquidMarkupRegex = regexp.MustCompile(`(\{\{[^}]*\}\}|\{%[^%]*%\})`)
+
 // cleanLiquidTemplate removes non-breaking spaces and other invisible characters from Liquid template variables
 func cleanLiquidTemplate(content string) string {
 	// Replace non-breaking spaces (\u00a0) with regular spaces within {{ }} and {% %} blocks
-	// This regex finds Liquid template variables and removes non-breaking spaces from them
-	liquidVarRegex := regexp.MustCompile(`(\{\{[^}]*\}\}|\{%[^%]*%\})`)
-
-	return liquidVarRegex.ReplaceAllStringFunc(content, func(match string) string {
+	return liquidMarkupRegex.ReplaceAllStringFunc(content, func(match string) string {
 		// Remove HTML entity non-breaking spaces that rich text editors (like Tiptap) commonly insert
 		cleaned := strings.ReplaceAll(match, "&nbsp;", " ")  // HTML named entity → regular space
 		cleaned = strings.ReplaceAll(cleaned, "&#160;", " ") // HTML numeric entity → regular space
 		cleaned = strings.ReplaceAll(cleaned, "&#xa0;", " ") // HTML hex entity → regular space
 		cleaned = strings.ReplaceAll(cleaned, "&#xA0;", " ") // HTML hex entity uppercase → regular space
 		// Remove Unicode non-breaking spaces and other invisible characters
-		cleaned = strings.ReplaceAll(cleaned, "\u00a0", "")  // Non-breaking space
+		cleaned = strings.ReplaceAll(cleaned, "\u00a0", "") // Non-breaking space
 		cleaned = strings.ReplaceAll(cleaned, "\u200b", "") // Zero-width space
 		cleaned = strings.ReplaceAll(cleaned, "\u2060", "") // Word joiner
 		cleaned = strings.ReplaceAll(cleaned, "\ufeff", "") // Byte order mark
@@ -544,11 +558,13 @@ func extractLiquidVariableName(value string) string {
 	return ""
 }
 
+// upperCaseRegex finds capital letters for camelCase to kebab-case conversion
+var upperCaseRegex = regexp.MustCompile("([A-Z])")
+
 // camelToKebab converts camelCase to kebab-case
 func camelToKebab(str string) string {
-	// Use regex to find capital letters and replace them with hyphen + lowercase
-	re := regexp.MustCompile("([A-Z])")
-	return re.ReplaceAllStringFunc(str, func(match string) string {
+	// Replace capital letters with hyphen + lowercase
+	return upperCaseRegex.ReplaceAllStringFunc(str, func(match string) string {
 		return "-" + strings.ToLower(match)
 	})
 }

--- a/pkg/notifuse_mjml/converter_test.go
+++ b/pkg/notifuse_mjml/converter_test.go
@@ -945,3 +945,41 @@ func TestMJLiquidNotPerBlockProcessed(t *testing.T) {
 		t.Errorf("Result should not contain <mj-liquid tag, got: %s", result)
 	}
 }
+
+func BenchmarkProcessLiquidContent(b *testing.B) {
+	content := "Hello {{ contact.first_name }}, welcome to {% if contact.language == 'en' %}our newsletter{% endif %}!"
+	data := map[string]interface{}{
+		"contact": map[string]interface{}{
+			"first_name": "Alice",
+			"language":   "en",
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := processLiquidContent(content, data, "bench-block"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkProcessLiquidContentParallel(b *testing.B) {
+	content := "Hello {{ contact.first_name }}!"
+	data := map[string]interface{}{
+		"contact": map[string]interface{}{"first_name": "Alice"},
+	}
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := processLiquidContent(content, data, "bench-block"); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkCamelToKebab(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		camelToKebab("backgroundColor")
+	}
+}


### PR DESCRIPTION
## Problem

`processLiquidContent` creates a new `SecureLiquidEngine` — a fresh `liquid.Environment` plus full standard-tag registration — for **every block of every render**. `cleanLiquidTemplate` and `camelToKebab` also recompile constant regexes per call. All three run per-block during email rendering, so a broadcast pays this cost thousands of times.

## Fix

Reuse engines through a `sync.Pool` and hoist the regexes to package level.

A pool is used instead of a shared instance deliberately: liquidgo's `Environment.CreateStrainer` reads and writes `strainerTemplateClassCache` without a lock during rendering, so a single engine must not be shared across goroutines. Verified with `go test -race ./pkg/notifuse_mjml/`.

## Results

| Benchmark | Before | After |
|---|---|---|
| ProcessLiquidContent | 28,424 ns/op · 338 allocs/op | 10,537 ns/op · 120 allocs/op |
| ProcessLiquidContentParallel | 17,504 ns/op | 2,418 ns/op |
| CamelToKebab | 624 ns/op · 17 allocs/op | 231 ns/op · 5 allocs/op |