### PR TITLE
perf: compile constant regexes once at package level

### DIFF
--- a/internal/service/automation_trigger_generator.go
+++ b/internal/service/automation_trigger_generator.go
@@ -207,6 +207,9 @@ func escapeString(s string) string {
 	return strings.ReplaceAll(s, "'", "''")
 }
 
+// placeholderRegex matches PostgreSQL placeholders ($1, $2, etc.)
+var placeholderRegex = regexp.MustCompile(`\$(\d+)`)
+
 // embedArgs replaces PostgreSQL placeholders ($1, $2, etc.) with properly escaped values.
 // This is necessary because PostgreSQL trigger WHEN clauses cannot use parameterized queries.
 // The function handles proper escaping to prevent SQL injection.
@@ -216,7 +219,6 @@ func embedArgs(sql string, args []interface{}) (string, error) {
 	}
 
 	// Find all placeholders and their positions
-	placeholderRegex := regexp.MustCompile(`\$(\d+)`)
 	matches := placeholderRegex.FindAllStringSubmatchIndex(sql, -1)
 
 	if len(matches) == 0 {

--- a/internal/service/automation_trigger_generator_test.go
+++ b/internal/service/automation_trigger_generator_test.go
@@ -662,3 +662,15 @@ func TestAutomationTriggerGenerator_Generate(t *testing.T) {
 		assert.NotContains(t, result.WHENClause, "NEW.changes ?")
 	})
 }
+
+func BenchmarkEmbedArgs(b *testing.B) {
+	sql := "NEW.kind = $1 AND NEW.email = $2 AND NEW.list_id = $3 AND NEW.status = $4"
+	args := []interface{}{"contact.created", "test@example.com", "list123", "active"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := embedArgs(sql, args); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/service/blog_toc.go
+++ b/internal/service/blog_toc.go
@@ -91,19 +91,25 @@ func getHeadingLevel(tagName string) int {
 	}
 }
 
+var (
+	anchorSeparatorRegex   = regexp.MustCompile(`[\s_]+`)
+	anchorInvalidCharRegex = regexp.MustCompile(`[^a-z0-9-]`)
+	anchorMultiHyphenRegex = regexp.MustCompile(`-+`)
+)
+
 // generateAnchorID creates a URL-friendly anchor ID from heading text
 func generateAnchorID(text string, index int) string {
 	// Convert to lowercase
 	id := strings.ToLower(text)
 
 	// Replace spaces and underscores with hyphens
-	id = regexp.MustCompile(`[\s_]+`).ReplaceAllString(id, "-")
+	id = anchorSeparatorRegex.ReplaceAllString(id, "-")
 
 	// Remove any characters that aren't lowercase letters, numbers, or hyphens
-	id = regexp.MustCompile(`[^a-z0-9-]`).ReplaceAllString(id, "")
+	id = anchorInvalidCharRegex.ReplaceAllString(id, "")
 
 	// Replace multiple consecutive hyphens with a single hyphen
-	id = regexp.MustCompile(`-+`).ReplaceAllString(id, "-")
+	id = anchorMultiHyphenRegex.ReplaceAllString(id, "-")
 
 	// Remove leading and trailing hyphens
 	id = strings.Trim(id, "-")

--- a/internal/service/blog_toc_test.go
+++ b/internal/service/blog_toc_test.go
@@ -303,3 +303,28 @@ func TestGenerateAnchorID(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkExtractTableOfContents(b *testing.B) {
+	// Simulate a typical blog post with multiple headings
+	var sb strings.Builder
+	for i := 0; i < 10; i++ {
+		sb.WriteString("<h2>Section Title Number ")
+		sb.WriteString(string(rune('A' + i)))
+		sb.WriteString("</h2><p>Some paragraph content here.</p><h3>Sub-Section_With Special!Chars</h3><p>More content.</p>")
+	}
+	html := sb.String()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, err := ExtractTableOfContents(html)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGenerateAnchorID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		generateAnchorID("Hello, World! This_Is a --- Heading", i)
+	}
+}


### PR DESCRIPTION
## Problem

`generateAnchorID` in `internal/service/blog_toc.go` compiles three regexes on every call — once per heading, on every blog post render. `embedArgs` in `internal/service/automation_trigger_generator.go` recompiles its placeholder pattern on every trigger generation. The patterns are constant, so the compilation is pure overhead.

## Fix

Hoist the four regexes to package-level `var`s — the same pattern already used in `template_service.go`. No behavior change. Benchmarks added.

## Results

| Benchmark | Before | After |
|---|---|---|
| ExtractTableOfContents | 60,389 ns/op · 1,204 allocs/op | 34,777 ns/op · 504 allocs/op |
| EmbedArgs | 1,700 ns/op · 42 allocs/op | 856 ns/op · 23 allocs/op |