### PR TITLE
Fix implicit TLS (SMTPS) handling on SMTP port 465

### DIFF
--- a/internal/service/setup_service.go
+++ b/internal/service/setup_service.go
@@ -495,16 +495,23 @@ func (s *SetupService) TestSMTPConnection(ctx context.Context, config *SMTPTestC
 		return fmt.Errorf("SMTP port is required")
 	}
 
-	// Determine TLS policy based on config
-	tlsPolicy := mail.TLSMandatory
-	if !config.UseTLS {
-		tlsPolicy = mail.NoTLS
-	}
-
 	// Build client options
 	clientOptions := []mail.Option{
 		mail.WithPort(config.Port),
-		mail.WithTLSPolicy(tlsPolicy),
+	}
+
+	// Port 465 is implicit TLS (SMTPS): the server expects the TLS handshake
+	// immediately, with no STARTTLS negotiation. TLSPolicy only controls
+	// STARTTLS, so using it on port 465 leaves the client waiting forever for
+	// a plaintext banner the server will never send. Use WithSSL() instead.
+	if config.UseTLS && config.Port == 465 {
+		clientOptions = append(clientOptions, mail.WithSSL())
+	} else {
+		tlsPolicy := mail.TLSMandatory
+		if !config.UseTLS {
+			tlsPolicy = mail.NoTLS
+		}
+		clientOptions = append(clientOptions, mail.WithTLSPolicy(tlsPolicy))
 	}
 
 	// Only add authentication if username and password are provided

--- a/internal/service/smtp_service.go
+++ b/internal/service/smtp_service.go
@@ -254,6 +254,23 @@ func sendRawEmailWithSettings(settings *domain.SMTPSettings, from string, to []s
 		return fmt.Errorf("failed to connect: %w", err)
 	}
 
+	// Port 465 is implicit TLS (SMTPS): the server expects the TLS handshake
+	// immediately, before any plaintext SMTP command - there is no greeting
+	// or STARTTLS step. Establish TLS right away and skip the STARTTLS branch
+	// below, otherwise the read of the plaintext greeting blocks forever.
+	implicitTLS := settings.UseTLS && settings.Port == 465
+	if implicitTLS {
+		tlsConfig := &tls.Config{
+			ServerName: settings.Host,
+			MinVersion: tls.VersionTLS12,
+		}
+		tlsConn := tls.Client(conn, tlsConfig)
+		if err := tlsConn.Handshake(); err != nil {
+			return fmt.Errorf("TLS handshake failed: %w", err)
+		}
+		conn = tlsConn
+	}
+
 	smtpConn := newSMTPConnection(conn)
 	defer smtpConn.Close()
 
@@ -287,8 +304,8 @@ func sendRawEmailWithSettings(settings *domain.SMTPSettings, from string, to []s
 	// post-TLS EHLO below, since many servers only advertise AUTH after STARTTLS.
 	authMechs := parseAuthMechanisms(ehloLines)
 
-	// STARTTLS if enabled
-	if settings.UseTLS {
+	// STARTTLS if enabled (skip when already using implicit TLS on port 465)
+	if settings.UseTLS && !implicitTLS {
 		code, _, err = smtpConn.sendCommand("STARTTLS")
 		if err != nil {
 			return fmt.Errorf("STARTTLS command failed: %w", err)

--- a/pkg/mailer/mailer.go
+++ b/pkg/mailer/mailer.go
@@ -304,17 +304,24 @@ func (m *SMTPMailer) createSMTPClient() (*mail.Client, error) {
 		return nil, nil
 	}
 
-	// Determine TLS policy based on config
-	tlsPolicy := mail.TLSOpportunistic
-	if !m.config.UseTLS {
-		tlsPolicy = mail.NoTLS
-	}
-
 	// Build client options
 	clientOptions := []mail.Option{
 		mail.WithPort(m.config.SMTPPort),
-		mail.WithTLSPolicy(tlsPolicy),
 		mail.WithTimeout(10 * time.Second),
+	}
+
+	// Port 465 is implicit TLS (SMTPS): the server expects the TLS handshake
+	// immediately, with no STARTTLS negotiation. TLSPolicy only controls
+	// STARTTLS, so using it on port 465 leaves the client waiting forever for
+	// a plaintext banner the server will never send. Use WithSSL() instead.
+	if m.config.UseTLS && m.config.SMTPPort == 465 {
+		clientOptions = append(clientOptions, mail.WithSSL())
+	} else {
+		tlsPolicy := mail.TLSOpportunistic
+		if !m.config.UseTLS {
+			tlsPolicy = mail.NoTLS
+		}
+		clientOptions = append(clientOptions, mail.WithTLSPolicy(tlsPolicy))
 	}
 
 	// Only add authentication if username and password are provided


### PR DESCRIPTION
Fixes #385

### Problem

Port 465 is implicit TLS (SMTPS): the server expects the TLS handshake immediately after the TCP connection is opened, with no plaintext greeting and no `STARTTLS` negotiation. The SMTP client code always configured a `TLSPolicy` (which only governs `STARTTLS`), so on port 465 it ended up waiting for a plaintext response the server would never send. The connection would hang or fail instead of succeeding.

### Fix

When TLS is enabled and the port is `465`, establish TLS immediately instead of relying on `STARTTLS`:

- `internal/service/setup_service.go` (`TestSMTPConnection`): use `mail.WithSSL()` instead of `mail.WithTLSPolicy(...)` when `UseTLS && Port == 465`.
- `pkg/mailer/mailer.go` (`SMTPMailer.createSMTPClient`): same change, using `mail.WithSSL()` for port 465.
- `internal/service/smtp_service.go` (`sendRawEmailWithSettings`): wrap the raw connection with `tls.Client(conn, tlsConfig)` and perform the handshake right after connecting when `UseTLS && Port == 465`, and skip the subsequent `STARTTLS` command since the connection is already secured.

All other ports/configurations (STARTTLS on 587, plaintext on 25, etc.) are unaffected. The existing `TLSPolicy`/`STARTTLS` behavior is preserved.

### Testing

- Verified `TestSMTPConnection` and outgoing mail sending succeed against a port-465/SMTPS SMTP provider.
- Verified STARTTLS-based providers (e.g. port 587) and unauthenticated/plaintext SMTP still work as before.
