### PR TITLE
compose: expose LOG_LEVEL env var with info default

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -15,6 +15,7 @@ services:
       - SERVER_PORT=${SERVER_PORT:-8080}
       - SERVER_HOST=${SERVER_HOST:-0.0.0.0}
       - ENVIRONMENT=${ENVIRONMENT:-production}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
 
       # Database Configuration (Required)
       - DB_HOST=${DB_HOST:-postgres}


### PR DESCRIPTION
the sample env include LOG_LEVEL but it's not actually being used by compose.yaml ...