### PR TITLE
oidc: stop persisting bare openid scopes from empty setup input

### DIFF
--- a/config/oidc.go
+++ b/config/oidc.go
@@ -29,6 +29,13 @@ const oidcCallbackPath = "/api/user.oidc.callback"
 // defaultOIDCScopes is used when neither env nor DB supplies scopes.
 const defaultOIDCScopes = "openid email profile"
 
+// DefaultOIDCScopes is the canonical default OIDC scope set. Callers that
+// persist scopes (setup wizard, settings update) must use this when the
+// incoming value is empty so they do not write ParseScopes("") → "openid"
+// alone into the database (which would permanently override the runtime
+// default and drop email/profile claims from the authorize request).
+const DefaultOIDCScopes = defaultOIDCScopes
+
 // defaultOIDCButtonLabel is the fallback sign-in button text.
 const defaultOIDCButtonLabel = "Sign in with SSO"
 
@@ -147,9 +154,18 @@ func resolveOIDCConfig(env EnvValues, ss *SystemSettings, isInstalled bool, apiE
 	}
 
 	// Scopes: env raw, else DB raw, else default; always force-include openid.
+	//
+	// A DB value of exactly "openid" is treated as the legacy setup-wizard bug:
+	// the wizard has no scopes field, so setup called ParseScopes("") and
+	// persisted the result ("openid" only). That value then permanently overrode
+	// the runtime default and caused authorize requests to omit email/profile.
+	// Heal it to the full default. An explicit env OIDC_SCOPES=openid is left alone.
 	rawScopes := env.OIDCScopes
 	if rawScopes == "" && hasDB {
 		rawScopes = ss.OIDCScopes
+		if strings.TrimSpace(rawScopes) == "openid" {
+			rawScopes = defaultOIDCScopes
+		}
 	}
 	if rawScopes == "" {
 		rawScopes = defaultOIDCScopes

--- a/config/oidc_test.go
+++ b/config/oidc_test.go
@@ -163,9 +163,9 @@ func TestResolveOIDCConfig_EnvWins(t *testing.T) {
 		OIDCButtonLabel:  "Env SSO",
 	}
 	ss := &SystemSettings{
-		OIDCEnabled:   true,
-		OIDCIssuerURL: "https://db-idp.example.com",
-		OIDCClientID:  "db-client",
+		OIDCEnabled:     true,
+		OIDCIssuerURL:   "https://db-idp.example.com",
+		OIDCClientID:    "db-client",
 		OIDCButtonLabel: "DB SSO",
 	}
 	c := resolveOIDCConfig(env, ss, true, "https://app.example.com")
@@ -183,14 +183,14 @@ func TestResolveOIDCConfig_EnvWins(t *testing.T) {
 func TestResolveOIDCConfig_DBFallbackWhenInstalled(t *testing.T) {
 	env := EnvValues{} // nothing from env
 	ss := &SystemSettings{
-		OIDCEnabled:        true,
-		OIDCIssuerURL:      "https://db-idp.example.com",
-		OIDCClientID:       "db-client",
-		OIDCClientSecret:   "db-secret",
-		OIDCScopes:         "openid email profile",
-		OIDCButtonLabel:    "DB SSO",
+		OIDCEnabled:         true,
+		OIDCIssuerURL:       "https://db-idp.example.com",
+		OIDCClientID:        "db-client",
+		OIDCClientSecret:    "db-secret",
+		OIDCScopes:          "openid email profile",
+		OIDCButtonLabel:     "DB SSO",
 		OIDCAutoCreateUsers: true,
-		OIDCAllowedDomains: "Corp.com, Sub.Corp.com",
+		OIDCAllowedDomains:  "Corp.com, Sub.Corp.com",
 	}
 	c := resolveOIDCConfig(env, ss, true, "https://app.example.com/")
 
@@ -222,6 +222,29 @@ func TestResolveOIDCConfig_RedirectDefaultScopesAndLabel(t *testing.T) {
 	assert.Equal(t, "https://app.example.com/api/user.oidc.callback", c.RedirectURI)
 	assert.Equal(t, []string{"openid", "email", "profile"}, c.Scopes, "default scopes when none provided")
 	assert.Equal(t, "Sign in with SSO", c.ButtonLabel, "default button label")
+}
+
+func TestResolveOIDCConfig_HealsLegacyDBOpenidOnly(t *testing.T) {
+	// Setup wizard used to call ParseScopes("") and persist "openid", which then
+	// permanently overrode the runtime default. Boot must heal that value.
+	env := EnvValues{}
+	ss := &SystemSettings{
+		OIDCEnabled:      true,
+		OIDCIssuerURL:    "https://db-idp.example.com",
+		OIDCClientID:     "db-client",
+		OIDCClientSecret: "db-secret",
+		OIDCScopes:       "openid",
+	}
+	c := resolveOIDCConfig(env, ss, true, "https://app.example.com")
+	assert.Equal(t, []string{"openid", "email", "profile"}, c.Scopes)
+}
+
+func TestResolveOIDCConfig_ExplicitEnvOpenidOnlyNotHealed(t *testing.T) {
+	// An operator who deliberately sets OIDC_SCOPES=openid must be respected.
+	env := EnvValues{OIDCScopes: "openid"}
+	ss := &SystemSettings{OIDCScopes: "openid email profile"}
+	c := resolveOIDCConfig(env, ss, true, "https://app.example.com")
+	assert.Equal(t, []string{"openid"}, c.Scopes)
 }
 
 func TestConfig_IsAllowedOIDCDomain(t *testing.T) {

--- a/config/oidc_test.go
+++ b/config/oidc_test.go
@@ -247,6 +247,20 @@ func TestResolveOIDCConfig_ExplicitEnvOpenidOnlyNotHealed(t *testing.T) {
 	assert.Equal(t, []string{"openid"}, c.Scopes)
 }
 
+func TestResolveOIDCConfig_DBOpenidEmailNotHealed(t *testing.T) {
+	// Non-legacy DB scopes must be kept as-is (heal only matches bare "openid").
+	env := EnvValues{}
+	ss := &SystemSettings{
+		OIDCEnabled:      true,
+		OIDCIssuerURL:    "https://db-idp.example.com",
+		OIDCClientID:     "db-client",
+		OIDCClientSecret: "db-secret",
+		OIDCScopes:       "openid email",
+	}
+	c := resolveOIDCConfig(env, ss, true, "https://app.example.com")
+	assert.Equal(t, []string{"openid", "email"}, c.Scopes)
+}
+
 func TestConfig_IsAllowedOIDCDomain(t *testing.T) {
 	c := &Config{OIDC: OIDCConfig{AllowedDomains: []string{"corp.com", "sub.corp.com"}}}
 

--- a/internal/http/settings_handler.go
+++ b/internal/http/settings_handler.go
@@ -16,16 +16,16 @@ import (
 )
 
 const (
-	passwordMask    = "\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022" // ••••••••
-	configuredMask  = "[configured]"
+	passwordMask   = "\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022" // ••••••••
+	configuredMask = "[configured]"
 )
 
 // SystemSettingsData represents the editable system settings
 type SystemSettingsData struct {
-	RootEmail              string `json:"root_email"`
-	APIEndpoint            string `json:"api_endpoint"`
-	SMTPHost               string `json:"smtp_host"`
-	SMTPPort               int    `json:"smtp_port"`
+	RootEmail               string `json:"root_email"`
+	APIEndpoint             string `json:"api_endpoint"`
+	SMTPHost                string `json:"smtp_host"`
+	SMTPPort                int    `json:"smtp_port"`
 	SMTPUsername            string `json:"smtp_username"`
 	SMTPPassword            string `json:"smtp_password"`
 	SMTPFromEmail           string `json:"smtp_from_email"`
@@ -53,7 +53,7 @@ type SystemSettingsData struct {
 // SystemSettingsResponse wraps settings with env override info
 type SystemSettingsResponse struct {
 	Settings     SystemSettingsData `json:"settings"`
-	EnvOverrides map[string]bool   `json:"env_overrides"`
+	EnvOverrides map[string]bool    `json:"env_overrides"`
 }
 
 // SettingsHandler handles system settings endpoints (root user only)
@@ -323,6 +323,17 @@ func (h *SettingsHandler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		oidcClientSecret = currentConfig.OIDCClientSecret
 	}
 
+	// Empty scopes must become the full default — same rule as setup_service.
+	// ParseScopes("") yields only "openid", which would permanently override the
+	// runtime default and break IdPs that put email/profile behind those scopes.
+	oidcScopes := reqData.OIDCScopes
+	if reqData.OIDCEnabled {
+		if strings.TrimSpace(oidcScopes) == "" {
+			oidcScopes = config.DefaultOIDCScopes
+		}
+		oidcScopes = strings.Join(config.ParseScopes(oidcScopes), " ")
+	}
+
 	// Build SystemConfig for persistence
 	newConfig := &service.SystemConfig{
 		IsInstalled:             true,
@@ -348,7 +359,7 @@ func (h *SettingsHandler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		OIDCClientID:            reqData.OIDCClientID,
 		OIDCClientSecret:        oidcClientSecret,
 		OIDCRedirectURI:         reqData.OIDCRedirectURI,
-		OIDCScopes:              reqData.OIDCScopes,
+		OIDCScopes:              oidcScopes,
 		OIDCButtonLabel:         reqData.OIDCButtonLabel,
 		OIDCAutoCreateUsers:     reqData.OIDCAutoCreateUsers,
 		OIDCAllowedDomains:      reqData.OIDCAllowedDomains,

--- a/internal/http/settings_handler_test.go
+++ b/internal/http/settings_handler_test.go
@@ -847,3 +847,57 @@ func TestSettingsHandler_Update_OIDCSecretMaskRetainsExisting(t *testing.T) {
 		"submitting the mask sentinel must retain the existing OIDC client secret")
 	assert.Equal(t, "Sign in with Acme", settingRepo.settings["oidc_button_label"], "the unrelated change must persist")
 }
+
+// TestSettingsHandler_Update_OIDCEmptyScopesDefaults ensures clearing/omitting scopes
+// with OIDC enabled persists the full default set, not bare "openid" from ParseScopes("").
+func TestSettingsHandler_Update_OIDCEmptyScopesDefaults(t *testing.T) {
+	handler, settingRepo, _, _ := setupSettingsHandler(t)
+
+	ctx := context.Background()
+	_ = settingRepo.Set(ctx, "is_installed", "true")
+	_ = settingRepo.Set(ctx, "root_email", testRootEmail)
+
+	update := SystemSettingsData{
+		RootEmail:        testRootEmail,
+		APIEndpoint:      "https://app.example.com",
+		OIDCEnabled:      true,
+		OIDCIssuerURL:    "https://idp.example.com",
+		OIDCClientID:     "cid",
+		OIDCClientSecret: "secret",
+		OIDCScopes:       "", // empty — must become default
+	}
+	body, _ := json.Marshal(update)
+	req := httptest.NewRequest(http.MethodPost, "/api/settings.update", bytes.NewBuffer(body))
+	req = reqWithUserContext(req, "root-user-id")
+	w := httptest.NewRecorder()
+	handler.handleUpdate(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "openid email profile", settingRepo.settings["oidc_scopes"])
+}
+
+// TestSettingsHandler_Update_OIDCExplicitScopesPreserved ensures a non-empty scopes
+// value is normalized via ParseScopes but not replaced with the full default.
+func TestSettingsHandler_Update_OIDCExplicitScopesPreserved(t *testing.T) {
+	handler, settingRepo, _, _ := setupSettingsHandler(t)
+
+	ctx := context.Background()
+	_ = settingRepo.Set(ctx, "is_installed", "true")
+	_ = settingRepo.Set(ctx, "root_email", testRootEmail)
+
+	update := SystemSettingsData{
+		RootEmail:        testRootEmail,
+		APIEndpoint:      "https://app.example.com",
+		OIDCEnabled:      true,
+		OIDCIssuerURL:    "https://idp.example.com",
+		OIDCClientID:     "cid",
+		OIDCClientSecret: "secret",
+		OIDCScopes:       "openid email", // intentional subset — must not expand to full default
+	}
+	body, _ := json.Marshal(update)
+	req := httptest.NewRequest(http.MethodPost, "/api/settings.update", bytes.NewBuffer(body))
+	req = reqWithUserContext(req, "root-user-id")
+	w := httptest.NewRecorder()
+	handler.handleUpdate(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "openid email", settingRepo.settings["oidc_scopes"])
+}

--- a/internal/service/setup_service.go
+++ b/internal/service/setup_service.go
@@ -16,18 +16,18 @@ import (
 
 // SetupConfig represents the setup initialization configuration
 type SetupConfig struct {
-	RootEmail              string
-	APIEndpoint            string
-	SMTPHost               string
-	SMTPPort               int
-	SMTPUsername           string
-	SMTPPassword           string
-	SMTPFromEmail          string
-	SMTPFromName           string
-	SMTPUseTLS             bool
-	SMTPEHLOHostname       string
-	TelemetryEnabled       bool
-	CheckForUpdates        bool
+	RootEmail               string
+	APIEndpoint             string
+	SMTPHost                string
+	SMTPPort                int
+	SMTPUsername            string
+	SMTPPassword            string
+	SMTPFromEmail           string
+	SMTPFromName            string
+	SMTPUseTLS              bool
+	SMTPEHLOHostname        string
+	TelemetryEnabled        bool
+	CheckForUpdates         bool
 	SMTPBridgeEnabled       bool
 	SMTPBridgeDomain        string
 	SMTPBridgePort          int
@@ -61,8 +61,8 @@ type ConfigurationStatus struct {
 	SMTPConfigured        bool
 	APIEndpointConfigured bool
 	RootEmailConfigured   bool
-	SMTPBridgeConfigured   bool
-	OIDCConfigured         bool
+	SMTPBridgeConfigured  bool
+	OIDCConfigured        bool
 }
 
 // SetupService handles setup wizard operations
@@ -78,16 +78,16 @@ type SetupService struct {
 
 // EnvironmentConfig holds configuration from environment variables
 type EnvironmentConfig struct {
-	RootEmail              string
-	APIEndpoint            string
-	SMTPHost               string
-	SMTPPort               int
-	SMTPUsername           string
-	SMTPPassword           string
-	SMTPFromEmail          string
-	SMTPFromName           string
-	SMTPUseTLS             string // "true", "false", or "" (empty = not set, defaults to true)
-	SMTPEHLOHostname       string
+	RootEmail               string
+	APIEndpoint             string
+	SMTPHost                string
+	SMTPPort                int
+	SMTPUsername            string
+	SMTPPassword            string
+	SMTPFromEmail           string
+	SMTPFromName            string
+	SMTPUseTLS              string // "true", "false", or "" (empty = not set, defaults to true)
+	SMTPEHLOHostname        string
 	SMTPBridgeEnabled       string // "true", "false", or "" (empty = not set, allows setup wizard to configure)
 	SMTPBridgeDomain        string
 	SMTPBridgePort          int
@@ -135,8 +135,8 @@ func (s *SetupService) GetConfigurationStatus() *ConfigurationStatus {
 			SMTPConfigured:        false,
 			APIEndpointConfigured: false,
 			RootEmailConfigured:   false,
-			SMTPBridgeConfigured:   false,
-			OIDCConfigured:         false,
+			SMTPBridgeConfigured:  false,
+			OIDCConfigured:        false,
 		}
 	}
 
@@ -164,8 +164,8 @@ func (s *SetupService) GetConfigurationStatus() *ConfigurationStatus {
 		SMTPConfigured:        smtpConfigured,
 		APIEndpointConfigured: s.envConfig.APIEndpoint != "",
 		RootEmailConfigured:   s.envConfig.RootEmail != "",
-		SMTPBridgeConfigured:   smtpBridgeConfigured,
-		OIDCConfigured:         oidcConfigured,
+		SMTPBridgeConfigured:  smtpBridgeConfigured,
+		OIDCConfigured:        oidcConfigured,
 	}
 }
 
@@ -409,25 +409,32 @@ func (s *SetupService) Initialize(ctx context.Context, config *SetupConfig) erro
 		oidcAllowedDomains = config.OIDCAllowedDomains
 	}
 	// Persist scopes with "openid" forced in (single source of truth at read time too).
+	// Empty scopes must become the full default — NOT ParseScopes(""), which yields
+	// only "openid". The setup wizard has no oidc_scopes field, so the JSON payload
+	// always arrives empty; writing bare "openid" permanently overrides the runtime
+	// default and breaks providers that put email/profile claims behind those scopes.
 	if oidcEnabled {
+		if strings.TrimSpace(oidcScopes) == "" {
+			oidcScopes = appconfig.DefaultOIDCScopes
+		}
 		oidcScopes = strings.Join(appconfig.ParseScopes(oidcScopes), " ")
 	}
 
 	// Store system settings
 	systemConfig := &SystemConfig{
-		IsInstalled:            true,
-		RootEmail:              finalConfig.RootEmail,
-		APIEndpoint:            finalConfig.APIEndpoint,
-		SMTPHost:               smtpHost,
-		SMTPPort:               smtpPort,
-		SMTPUsername:           smtpUsername,
-		SMTPPassword:           smtpPassword,
-		SMTPFromEmail:          smtpFromEmail,
-		SMTPFromName:           smtpFromName,
-		SMTPUseTLS:             smtpUseTLS,
-		SMTPEHLOHostname:       smtpEHLOHostname,
-		TelemetryEnabled:       config.TelemetryEnabled,
-		CheckForUpdates:        config.CheckForUpdates,
+		IsInstalled:             true,
+		RootEmail:               finalConfig.RootEmail,
+		APIEndpoint:             finalConfig.APIEndpoint,
+		SMTPHost:                smtpHost,
+		SMTPPort:                smtpPort,
+		SMTPUsername:            smtpUsername,
+		SMTPPassword:            smtpPassword,
+		SMTPFromEmail:           smtpFromEmail,
+		SMTPFromName:            smtpFromName,
+		SMTPUseTLS:              smtpUseTLS,
+		SMTPEHLOHostname:        smtpEHLOHostname,
+		TelemetryEnabled:        config.TelemetryEnabled,
+		CheckForUpdates:         config.CheckForUpdates,
 		SMTPBridgeEnabled:       smtpBridgeEnabled,
 		SMTPBridgeDomain:        smtpBridgeDomain,
 		SMTPBridgePort:          smtpBridgePort,

--- a/internal/service/setup_service_test.go
+++ b/internal/service/setup_service_test.go
@@ -3,7 +3,9 @@ package service_test
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/Notifuse/notifuse/internal/domain"
 	"github.com/Notifuse/notifuse/internal/service"
 	"github.com/Notifuse/notifuse/pkg/logger"
 	"github.com/stretchr/testify/assert"
@@ -245,6 +247,144 @@ func TestSetupService_OIDC_StatusAndValidation(t *testing.T) {
 		})
 		require.NoError(t, err)
 	})
+}
+
+// stubUserRepo is a minimal UserRepository for Initialize tests that only need CreateUser.
+type stubUserRepo struct {
+	created []*domain.User
+}
+
+func (s *stubUserRepo) CreateUser(ctx context.Context, user *domain.User) error {
+	s.created = append(s.created, user)
+	return nil
+}
+func (s *stubUserRepo) GetUserByID(ctx context.Context, id string) (*domain.User, error) {
+	return nil, nil
+}
+func (s *stubUserRepo) GetUserByEmail(ctx context.Context, email string) (*domain.User, error) {
+	return nil, nil
+}
+func (s *stubUserRepo) GetUserByEmailInsensitive(ctx context.Context, email string) (*domain.User, error) {
+	return nil, nil
+}
+func (s *stubUserRepo) UpdateUserLanguage(ctx context.Context, userID string, language string) error {
+	return nil
+}
+func (s *stubUserRepo) CreateSession(ctx context.Context, session *domain.Session) error {
+	return nil
+}
+func (s *stubUserRepo) GetSessionByID(ctx context.Context, id string) (*domain.Session, error) {
+	return nil, nil
+}
+func (s *stubUserRepo) GetSessionsByUserID(ctx context.Context, userID string) ([]*domain.Session, error) {
+	return nil, nil
+}
+func (s *stubUserRepo) UpdateSession(ctx context.Context, session *domain.Session) error {
+	return nil
+}
+func (s *stubUserRepo) DeleteSession(ctx context.Context, id string) error { return nil }
+func (s *stubUserRepo) DeleteAllSessionsByUserID(ctx context.Context, userID string) error {
+	return nil
+}
+func (s *stubUserRepo) Delete(ctx context.Context, id string) error { return nil }
+
+// stubSettingRepo is a minimal SettingRepository that exposes stored values for assertions.
+type stubSettingRepo struct {
+	settings map[string]string
+}
+
+func newStubSettingRepo() *stubSettingRepo {
+	return &stubSettingRepo{settings: make(map[string]string)}
+}
+
+func (m *stubSettingRepo) Get(ctx context.Context, key string) (*domain.Setting, error) {
+	value, exists := m.settings[key]
+	if !exists {
+		return nil, &domain.ErrSettingNotFound{Key: key}
+	}
+	return &domain.Setting{Key: key, Value: value}, nil
+}
+func (m *stubSettingRepo) Set(ctx context.Context, key, value string) error {
+	m.settings[key] = value
+	return nil
+}
+func (m *stubSettingRepo) Delete(ctx context.Context, key string) error {
+	delete(m.settings, key)
+	return nil
+}
+func (m *stubSettingRepo) List(ctx context.Context) ([]*domain.Setting, error) {
+	out := make([]*domain.Setting, 0, len(m.settings))
+	for k, v := range m.settings {
+		out = append(out, &domain.Setting{Key: k, Value: v})
+	}
+	return out, nil
+}
+func (m *stubSettingRepo) GetLastCronRun(ctx context.Context) (*time.Time, error) { return nil, nil }
+func (m *stubSettingRepo) SetLastCronRun(ctx context.Context) error               { return nil }
+
+func TestSetupService_Initialize_OIDCEmptyScopesDefaults(t *testing.T) {
+	// Wizard never sends oidc_scopes; empty must become DefaultOIDCScopes, not bare openid.
+	repo := newStubSettingRepo()
+	userRepo := &stubUserRepo{}
+	settingService := service.NewSettingService(repo)
+	setupService := service.NewSetupService(
+		settingService,
+		&service.UserService{},
+		userRepo,
+		&mockLogger{},
+		"test-secret-key-for-encryption-32b",
+		nil,
+		nil,
+	)
+
+	err := setupService.Initialize(context.Background(), &service.SetupConfig{
+		RootEmail:        "admin@example.com",
+		APIEndpoint:      "https://app.example.com",
+		SMTPHost:         "smtp.example.com",
+		SMTPPort:         587,
+		SMTPFromEmail:    "noreply@example.com",
+		OIDCEnabled:      true,
+		OIDCIssuerURL:    "https://idp.example.com",
+		OIDCClientID:     "client-id",
+		OIDCClientSecret: "client-secret",
+		// OIDCScopes intentionally empty (wizard has no field)
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "openid email profile", repo.settings["oidc_scopes"])
+	assert.Equal(t, "true", repo.settings["oidc_enabled"])
+}
+
+func TestSetupService_Initialize_OIDCEnvScopesPersisted(t *testing.T) {
+	// Env-configured OIDC scopes win and are normalized via ParseScopes before persist.
+	repo := newStubSettingRepo()
+	userRepo := &stubUserRepo{}
+	settingService := service.NewSettingService(repo)
+	setupService := service.NewSetupService(
+		settingService,
+		&service.UserService{},
+		userRepo,
+		&mockLogger{},
+		"test-secret-key-for-encryption-32b",
+		nil,
+		&service.EnvironmentConfig{
+			OIDCEnabled:      "true",
+			OIDCIssuerURL:    "https://idp.example.com",
+			OIDCClientID:     "env-client",
+			OIDCClientSecret: "env-secret",
+			OIDCScopes:       "email profile", // openid forced by ParseScopes
+		},
+	)
+
+	err := setupService.Initialize(context.Background(), &service.SetupConfig{
+		RootEmail:     "admin@example.com",
+		APIEndpoint:   "https://app.example.com",
+		SMTPHost:      "smtp.example.com",
+		SMTPPort:      587,
+		SMTPFromEmail: "noreply@example.com",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "openid email profile", repo.settings["oidc_scopes"])
+	assert.Equal(t, "env-client", repo.settings["oidc_client_id"])
 }
 
 func TestSetupService_GetEnvOverrides(t *testing.T) {


### PR DESCRIPTION
### AI Disclamer
As I was unable to make my OIDC work, I asked my AI for help. It kept hallucinating again and again on why i was getting "email validation" errors. Then it dawned on me that cloudflare access OIDC didn't give any email ... because notifuse didn't ask any!! If the default include all 3, why was mine only asking openid? turns out the setup add "" in db, and "openid" + "" = "openid". And when theres a value in db, theres no need to take the default string for it. Anyways, the fix is made by AI. It opted to self heal bad database settings value. Anyways, this took too much time of my life so I hope this is useful. 

### Problem
Enabling OIDC via the setup wizard left instances requesting only the openid scope on the authorize URL.
The wizard has no oidc_scopes field, so setup always received an empty scopes string. The write path then did:
oidcScopes = strings.Join(ParseScopes(oidcScopes), " ")
ParseScopes("") always injects openid and returns only that value, which was persisted as oidc_scopes=openid. On later boots, the DB value overrode the code default (openid email profile), so IdPs that put email/profile claims behind those scopes returned tokens without email (e.g. Cloudflare Access).
### Fix
1. Setup / settings write paths — when OIDC is enabled and scopes are empty, persist DefaultOIDCScopes (openid email profile) before ParseScopes.
2. Config resolve — if the DB holds exactly openid (legacy bug) and env is unset, heal to the full default. Explicit OIDC_SCOPES=openid is left alone.
3. Export DefaultOIDCScopes for the shared write-path constant.
No migration required; existing broken rows are healed at boot. No API or frontend changes required.
### Testing
- TestSetupService_Initialize_OIDCEmptyScopesDefaults
- TestSetupService_Initialize_OIDCEnvScopesPersisted
- TestSettingsHandler_Update_OIDCEmptyScopesDefaults
- TestSettingsHandler_Update_OIDCExplicitScopesPreserved
- TestResolveOIDCConfig_HealsLegacyDBOpenidOnly
- TestResolveOIDCConfig_ExplicitEnvOpenidOnlyNotHealed
- TestResolveOIDCConfig_DBOpenidEmailNotHealed
make test-unit (race) passes on this branch.