### PR TITLE
Fix workspace delete privilege revokes

### DIFF
--- a/internal/repository/workspace_core_test.go
+++ b/internal/repository/workspace_core_test.go
@@ -786,13 +786,11 @@ func TestWorkspaceRepository_Delete_Postgres(t *testing.T) {
 
 	// Error from DeleteDatabase (revoke fails)
 	revokeQuery := fmt.Sprintf(`
-		REVOKE ALL PRIVILEGES ON DATABASE %s FROM PUBLIC;
-		REVOKE ALL PRIVILEGES ON DATABASE %s FROM %s;
-		REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM PUBLIC;
-		REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM %s;
-		REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM PUBLIC;
-		REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM %s;`,
-		dbName, dbName, dbConfig.User, dbConfig.User, dbConfig.User)
+		REVOKE CONNECT ON DATABASE %s FROM PUBLIC;
+		REVOKE CONNECT ON DATABASE %s FROM %s;`,
+		dbName, dbName, dbConfig.User)
+	assert.NotContains(t, revokeQuery, "ALL TABLES")
+	assert.NotContains(t, revokeQuery, "ALL SEQUENCES")
 	mock.ExpectExec(regexp.QuoteMeta(revokeQuery)).
 		WillReturnError(fmt.Errorf("perm denied"))
 	err := repo.Delete(context.Background(), workspaceID)

--- a/internal/repository/workspace_database_test.go
+++ b/internal/repository/workspace_database_test.go
@@ -134,13 +134,11 @@ func TestWorkspaceRepository_DeleteDatabase(t *testing.T) {
 
 	// First test: error case
 	revokeQuery := fmt.Sprintf(`
-		REVOKE ALL PRIVILEGES ON DATABASE %s FROM PUBLIC;
-		REVOKE ALL PRIVILEGES ON DATABASE %s FROM %s;
-		REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM PUBLIC;
-		REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM %s;
-		REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM PUBLIC;
-		REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM %s;`,
-		dbName, dbName, dbConfig.User, dbConfig.User, dbConfig.User)
+		REVOKE CONNECT ON DATABASE %s FROM PUBLIC;
+		REVOKE CONNECT ON DATABASE %s FROM %s;`,
+		dbName, dbName, dbConfig.User)
+	assert.NotContains(t, revokeQuery, "ALL TABLES")
+	assert.NotContains(t, revokeQuery, "ALL SEQUENCES")
 	mock.ExpectExec(regexp.QuoteMeta(revokeQuery)).
 		WillReturnError(errors.New("permission denied"))
 

--- a/internal/repository/workspace_postgres.go
+++ b/internal/repository/workspace_postgres.go
@@ -344,15 +344,13 @@ func (r *workspaceRepository) DeleteDatabase(ctx context.Context, workspaceID st
 		fmt.Printf("Warning: failed to close workspace connection: %v\n", err)
 	}
 
-	// First, revoke all privileges to prevent new connections
+	// First, revoke CONNECT on the target database to prevent new connections.
+	// Schema/table/sequence privileges are intentionally not revoked here because
+	// this connection is to the system database, not the workspace database.
 	revokeQuery := fmt.Sprintf(`
-		REVOKE ALL PRIVILEGES ON DATABASE %s FROM PUBLIC;
-		REVOKE ALL PRIVILEGES ON DATABASE %s FROM %s;
-		REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM PUBLIC;
-		REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM %s;
-		REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM PUBLIC;
-		REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM %s;`,
-		dbName, dbName, r.dbConfig.User, r.dbConfig.User, r.dbConfig.User)
+		REVOKE CONNECT ON DATABASE %s FROM PUBLIC;
+		REVOKE CONNECT ON DATABASE %s FROM %s;`,
+		dbName, dbName, r.dbConfig.User)
 	if _, err := r.systemDB.ExecContext(ctx, revokeQuery); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- limit `DeleteDatabase` pre-drop revokes to `CONNECT` on the target workspace database
- avoid revoking table and sequence privileges through the system database connection
- update focused tests to guard against schema object revokes in the delete flow

## Root cause

`DeleteDatabase` uses `r.systemDB` while preparing to drop a workspace database. The previous query included `REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public` and `REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public`, so those statements targeted the system database public schema instead of the workspace database.

## Validation

- `go test ./internal/repository`

Fixes #396